### PR TITLE
Refactor CpsEncoder to fix indexing in pair iteration logic

### DIFF
--- a/crates/bpetok/src/tokenizer/cps_encoder.rs
+++ b/crates/bpetok/src/tokenizer/cps_encoder.rs
@@ -134,7 +134,7 @@ impl<T: TokenType> CPSEncoder<T> {
             let mut best_match: Option<(usize, T)> = None;
 
             for idx in start..buf.len() - 1 {
-                let pair = (buf[start], buf[start + 1]);
+                let pair = (buf[idx], buf[idx + 1]);
 
                 if let Some(&new_token) = self.data.merge_map.get(&pair)
                     && (best_match.is_none() || (new_token < best_match.unwrap().1))


### PR DESCRIPTION
No relevant issues were linked to this pull request.

### Overview
This pull request refactors the `CpsEncoder` by addressing an issue with incorrect indexing in the pair iteration logic during encoding, improving the reliability of the encoder.
