### PR TITLE
Refactor: rename `decoder` to `decoders` and `tokenizer` to `encoders…

### DIFF
--- a/crates/bpetok/examples/tokenizer_trainer/README.md
+++ b/crates/bpetok/examples/tokenizer_trainer/README.md
@@ -34,11 +34,11 @@ See: [original nanochat/speedrun.sh](https://github.com/karpathy/nanochat/blob/m
 # so we download 2e9 / 250e6 = 8 data shards at this point
 # each shard is ~100MB of text (compressed), so this is about ~800MB of data on disk
 python -m nanochat.dataset -n 8
-# Immediately also kick off downloading more shards in the background while tokenizer trains
+# Immediately also kick off downloading more shards in the background while encoders trains
 # See comment below for why 240 is the right number here
 python -m nanochat.dataset -n 240 &
 DATASET_DOWNLOAD_PID=$!
-# train the tokenizer with vocab size 2**16 = 65536 on ~2B characters of data
+# train the encoders with vocab size 2**16 = 65536 on ~2B characters of data
 python -m scripts.tok_train --max_chars=2000000000
 ```
 

--- a/crates/bpetok/examples/tokenizer_trainer/src/main.rs
+++ b/crates/bpetok/examples/tokenizer_trainer/src/main.rs
@@ -1,7 +1,7 @@
 use arrow::array::StringArray;
-use bpetok::decoder::parallel_decoder::ParallelDecoder;
-use bpetok::decoder::token_decoder::TokenDecoder;
-use bpetok::tokenizer::{TokenEncoder, UnifiedVocabEncoder};
+use bpetok::decoders::parallel_decoder::ParallelDecoder;
+use bpetok::decoders::token_decoder::TokenDecoder;
+use bpetok::encoders::{TokenEncoder, UnifiedVocabEncoder};
 use bpetok::training::trainer::{BPETokenVocabTrainer, TrainResults};
 use bpetok::types::TokenType;
 use bpetok::vocab::unified_vocab::UnifiedTokenVocab;
@@ -14,7 +14,7 @@ use std::collections::HashSet;
 use std::sync::Arc;
 use std::time::Duration;
 
-/// Example tokenizer trainer.
+/// Example encoders trainer.
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
 pub struct Args {

--- a/crates/bpetok/src/decoders/byte_decoder.rs
+++ b/crates/bpetok/src/decoders/byte_decoder.rs
@@ -2,11 +2,11 @@
 //!
 //! Mainly used for testing.
 
-use crate::decoder::{DecodeContext, TokenDecoder};
+use crate::decoders::{TokenDecodeContext, TokenDecoder};
 use crate::types::TokenType;
 use crate::vocab::TokenVocabIndex;
 
-/// A decoder that only decodes byte tokens.
+/// A decoders that only decodes byte tokens.
 #[derive(Clone, Default)]
 pub struct ByteDecoder<T: TokenType> {
     _marker: std::marker::PhantomData<T>,
@@ -22,7 +22,7 @@ impl<T: TokenType> TokenDecoder<T> for ByteDecoder<T> {
     #[cfg_attr(feature = "tracing", tracing::instrument(skip(self, buf, tokens)))]
     fn incremental_decode(
         &self,
-        ctx: &mut DecodeContext<T>,
+        ctx: &mut TokenDecodeContext<T>,
     ) -> bool {
         while let Some(t) = ctx.stack.pop() {
             if let Some(b) = t.to_u8() {
@@ -63,7 +63,7 @@ mod tests {
         );
         tokens.extend_from_slice(&[256, 3000]);
 
-        let mut ctx = DecodeContext::for_tokens(tokens, 2);
+        let mut ctx = TokenDecodeContext::for_tokens(tokens, 2);
         assert!(!decoder.incremental_decode(&mut ctx));
 
         assert_eq!(ctx.buf, "hello world".as_bytes().to_vec());

--- a/crates/bpetok/src/decoders/decode_context.rs
+++ b/crates/bpetok/src/decoders/decode_context.rs
@@ -4,7 +4,7 @@ use crate::types::TokenType;
 
 /// Representation of a token decoding context.
 #[derive(Clone)]
-pub struct DecodeContext<T: TokenType> {
+pub struct TokenDecodeContext<T: TokenType> {
     /// Append buffer for decoded bytes.
     pub buf: Vec<u8>,
 
@@ -12,7 +12,7 @@ pub struct DecodeContext<T: TokenType> {
     pub stack: Vec<T>,
 }
 
-impl<T: TokenType> DecodeContext<T> {
+impl<T: TokenType> TokenDecodeContext<T> {
     /// Creates a new decoding context.
     pub fn for_tokens(
         tokens: Vec<T>,

--- a/crates/bpetok/src/decoders/mod.rs
+++ b/crates/bpetok/src/decoders/mod.rs
@@ -1,12 +1,12 @@
 //! # Token Decoders
 
 pub mod byte_decoder;
-pub mod context;
+pub mod decode_context;
 pub mod dictionary_decoder;
 pub mod pair_decoder;
 pub mod parallel_decoder;
 pub mod token_decoder;
 
-pub use context::*;
+pub use decode_context::*;
 pub use dictionary_decoder::*;
 pub use token_decoder::*;

--- a/crates/bpetok/src/decoders/pair_decoder.rs
+++ b/crates/bpetok/src/decoders/pair_decoder.rs
@@ -1,44 +1,55 @@
-//! # Dictionary Decoder
+//! # Expansion Decoder
 
-use crate::decoder::context::DecodeContext;
-use crate::decoder::token_decoder::TokenDecoder;
-use crate::types::{TokenToWordMap, TokenType};
+use crate::decoders::decode_context::TokenDecodeContext;
+use crate::decoders::token_decoder::TokenDecoder;
+use crate::types::{PairToTokenMap, TokenToPairMap, TokenType};
 use crate::vocab::TokenVocabIndex;
 
-/// A token dictionary [`TokenDecoder<T>`].
+/// An [`ExpansionMap`] [`TokenDecoder<T>`].
 #[derive(Clone)]
-pub struct DictionaryDecoder<T: TokenType> {
-    /// Token to bytes mapping.
+pub struct PairExpansionDecoder<T: TokenType> {
+    /// Token to pair mapping.
     ///
     /// Does not include byte-tokens.
-    pub token_to_word: TokenToWordMap<T>,
+    pub token_to_pair: TokenToPairMap<T>,
 }
 
-impl<T: TokenType> DictionaryDecoder<T> {
+impl<T: TokenType> PairExpansionDecoder<T> {
     /// Creates a new Decoder.
-    pub fn new(mut token_to_word: TokenToWordMap<T>) -> Self {
-        token_to_word.shrink_to_fit();
-        Self { token_to_word }
+    pub fn new(mut token_to_pair: TokenToPairMap<T>) -> Self {
+        token_to_pair.shrink_to_fit();
+        Self { token_to_pair }
+    }
+
+    /// Build a [`PairExpansionDecoder`] from this [`Tokenizer`].
+    #[cfg_attr(feature = "tracing", tracing::instrument(skip(merge_map)))]
+    pub fn from_pair_map(merge_map: &PairToTokenMap<T>) -> Self {
+        let expansion_map = merge_map
+            .iter()
+            .map(|(&pair, &token)| (token, pair))
+            .collect();
+        Self::new(expansion_map)
     }
 }
 
-impl<T: TokenType> TokenVocabIndex<T> for DictionaryDecoder<T> {
+impl<T: TokenType> TokenVocabIndex<T> for PairExpansionDecoder<T> {
     fn compound_tokens_iter(&self) -> impl Iterator<Item = T> {
-        self.token_to_word.keys().copied()
+        self.token_to_pair.keys().copied()
     }
 }
 
-impl<T: TokenType> TokenDecoder<T> for DictionaryDecoder<T> {
+impl<T: TokenType> TokenDecoder<T> for PairExpansionDecoder<T> {
     #[cfg_attr(feature = "tracing", tracing::instrument(skip(self, buf, tokens)))]
     fn incremental_decode(
         &self,
-        ctx: &mut DecodeContext<T>,
+        ctx: &mut TokenDecodeContext<T>,
     ) -> bool {
         while let Some(t) = ctx.stack.pop() {
             if let Some(b) = t.to_u8() {
                 ctx.buf.push(b);
-            } else if let Some(w) = self.token_to_word.get(&t) {
-                ctx.buf.extend_from_slice(w.as_slice());
+            } else if let Some((a, b)) = self.token_to_pair.get(&t) {
+                ctx.stack.push(*b);
+                ctx.stack.push(*a);
             } else {
                 ctx.stack.push(t);
                 break;
@@ -51,8 +62,8 @@ impl<T: TokenType> TokenDecoder<T> for DictionaryDecoder<T> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::tokenizer::TokenEncoder;
-    use crate::tokenizer::unified_encoder::UnifiedVocabEncoder;
+    use crate::encoders::TokenEncoder;
+    use crate::encoders::unified_encoder::UnifiedVocabEncoder;
     use crate::training::trainer::{BPETokenVocabTrainer, TrainResults};
     use crate::types::{check_is_send, check_is_sync};
     use crate::vocab::unified_vocab::UnifiedTokenVocab;
@@ -60,7 +71,7 @@ mod tests {
     use std::sync::Arc;
 
     #[test]
-    fn test_dictionary_decoder() {
+    fn test_pair_decoder() {
         type T = u16;
         type C = u32;
         type K = CompactString;
@@ -86,7 +97,7 @@ mod tests {
 
         let encoder = UnifiedVocabEncoder::<T>::new(vocab.clone(), Default::default());
 
-        let decoder = DictionaryDecoder::new(vocab.compiled_dictionary());
+        let decoder = PairExpansionDecoder::from_pair_map(&vocab.pair_vocab.pairs);
         check_is_send(&decoder);
         check_is_sync(&decoder);
 

--- a/crates/bpetok/src/decoders/parallel_decoder.rs
+++ b/crates/bpetok/src/decoders/parallel_decoder.rs
@@ -1,6 +1,6 @@
 //! # Parallel Decoder
 
-use crate::decoder::{DecodeContext, TokenDecoder};
+use crate::decoders::{TokenDecodeContext, TokenDecoder};
 use crate::types::TokenType;
 use crate::vocab::TokenVocabIndex;
 
@@ -18,7 +18,7 @@ where
     T: TokenType,
     D: TokenDecoder<T>,
 {
-    /// Create a new parallel token decoder.
+    /// Create a new parallel token decoders.
     pub fn new(inner: D) -> Self {
         Self {
             inner,
@@ -44,7 +44,7 @@ where
 {
     fn incremental_decode(
         &self,
-        ctx: &mut DecodeContext<T>,
+        ctx: &mut TokenDecodeContext<T>,
     ) -> bool {
         self.inner.incremental_decode(ctx)
     }
@@ -71,8 +71,8 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::decoder::DictionaryDecoder;
-    use crate::tokenizer::{TokenEncoder, UnifiedVocabEncoder};
+    use crate::decoders::DictionaryDecoder;
+    use crate::encoders::{TokenEncoder, UnifiedVocabEncoder};
     use crate::training::trainer::{BPETokenVocabTrainer, TrainResults};
     use crate::types::{check_is_send, check_is_sync};
     use crate::vocab::unified_vocab::UnifiedTokenVocab;

--- a/crates/bpetok/src/decoders/token_decoder.rs
+++ b/crates/bpetok/src/decoders/token_decoder.rs
@@ -1,6 +1,6 @@
 //! # Token Decoder Trait
 
-use crate::decoder::DecodeContext;
+use crate::decoders::TokenDecodeContext;
 use crate::types::TokenType;
 use crate::vocab::TokenVocabIndex;
 
@@ -9,13 +9,13 @@ pub trait TokenDecoder<T: TokenType>: TokenVocabIndex<T> + Send + Sync {
     /// Incrementally decodes the context.
     ///
     /// Progresses until `ctx.stack` is empty,
-    /// or the top token cannot be decoded by this decoder.
+    /// or the top token cannot be decoded by this decoders.
     ///
     /// # Returns
     /// `ctx.stack.is_empty()`
     fn incremental_decode(
         &self,
-        ctx: &mut DecodeContext<T>,
+        ctx: &mut TokenDecodeContext<T>,
     ) -> bool;
 
     /// Decodes tokens into bytes.
@@ -25,8 +25,8 @@ pub trait TokenDecoder<T: TokenType>: TokenVocabIndex<T> + Send + Sync {
     fn decode_to_context<S: AsRef<[T]>>(
         &self,
         tokens: S,
-    ) -> DecodeContext<T> {
-        let mut context = DecodeContext::for_tokens(tokens.as_ref().to_vec(), 2);
+    ) -> TokenDecodeContext<T> {
+        let mut context = TokenDecodeContext::for_tokens(tokens.as_ref().to_vec(), 2);
         self.incremental_decode(&mut context);
         context
     }
@@ -71,7 +71,7 @@ pub trait TokenDecoder<T: TokenType>: TokenVocabIndex<T> + Send + Sync {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::decoder::byte_decoder::ByteDecoder;
+    use crate::decoders::byte_decoder::ByteDecoder;
     use num_traits::FromPrimitive;
 
     #[test]
@@ -96,7 +96,7 @@ mod tests {
         );
         tokens.extend_from_slice(&[256, 3000]);
 
-        let mut ctx = DecodeContext::for_tokens(tokens, 2);
+        let mut ctx = TokenDecodeContext::for_tokens(tokens, 2);
         assert!(!decoder.incremental_decode(&mut ctx));
 
         assert_eq!(ctx.buf, "hello world".as_bytes().to_vec());

--- a/crates/bpetok/src/encoders/mod.rs
+++ b/crates/bpetok/src/encoders/mod.rs
@@ -7,7 +7,7 @@ pub use unified_encoder::*;
 
 /// A trait for token encoders.
 pub trait TokenEncoder<T: TokenType> {
-    /// Returns the maximum token id in this decoder.
+    /// Returns the maximum token id in this decoders.
     fn max_token(&self) -> T;
 
     /// Encode text into tokens.

--- a/crates/bpetok/src/encoders/unified_encoder.rs
+++ b/crates/bpetok/src/encoders/unified_encoder.rs
@@ -1,8 +1,8 @@
 //! # Chunk Pair Scan Tokenizer
 
 use crate::DEFAULT_PARALLEL;
-use crate::decoder::dictionary_decoder::DictionaryDecoder;
-use crate::tokenizer::TokenEncoder;
+use crate::decoders::dictionary_decoder::DictionaryDecoder;
+use crate::encoders::TokenEncoder;
 use crate::types::TokenType;
 use crate::util::regex::regex_pool::RegexWrapperPool;
 use crate::util::regex::regex_wrapper::RegexWrapper;
@@ -41,7 +41,7 @@ impl Default for UnifiedVocabEncoderOptions {
 /// A Chunk/Pair Scanning [`TokenEncoder`].
 #[derive(Clone)]
 pub struct UnifiedVocabEncoder<T: TokenType> {
-    /// Data for the encoder.
+    /// Data for the encoders.
     pub data: Arc<UnifiedTokenVocab<T>>,
 
     /// Tokenizer options.
@@ -51,7 +51,7 @@ pub struct UnifiedVocabEncoder<T: TokenType> {
 }
 
 impl<T: TokenType> UnifiedVocabEncoder<T> {
-    /// Construct a new encoder..
+    /// Construct a new encoders..
     pub fn new(
         data: Arc<UnifiedTokenVocab<T>>,
         options: UnifiedVocabEncoderOptions,
@@ -166,9 +166,9 @@ impl<T: TokenType> TokenEncoder<T> for UnifiedVocabEncoder<T> {
 
 #[cfg(test)]
 mod tests {
-    use crate::decoder::token_decoder::TokenDecoder;
-    use crate::tokenizer::TokenEncoder;
-    use crate::tokenizer::unified_encoder::UnifiedVocabEncoder;
+    use crate::decoders::token_decoder::TokenDecoder;
+    use crate::encoders::TokenEncoder;
+    use crate::encoders::unified_encoder::UnifiedVocabEncoder;
     use crate::training::trainer::{BPETokenVocabTrainer, TrainResults};
     use crate::types::{check_is_send, check_is_sync};
     use crate::vocab::unified_vocab::UnifiedTokenVocab;

--- a/crates/bpetok/src/lib.rs
+++ b/crates/bpetok/src/lib.rs
@@ -1,8 +1,8 @@
 //! # BPE Tokenizer
 #![warn(missing_docs, unused)]
 
-pub mod decoder;
-pub mod tokenizer;
+pub mod decoders;
+pub mod encoders;
 pub mod training;
 pub mod types;
 pub mod util;

--- a/crates/bpetok/src/training/trainer.rs
+++ b/crates/bpetok/src/training/trainer.rs
@@ -329,9 +329,9 @@ impl<T: TokenType, C: CountType> Ord for MergeJob<T, C> {
 
 #[cfg(test)]
 mod tests {
-    use crate::decoder::token_decoder::TokenDecoder;
-    use crate::tokenizer::TokenEncoder;
-    use crate::tokenizer::unified_encoder::UnifiedVocabEncoder;
+    use crate::decoders::token_decoder::TokenDecoder;
+    use crate::encoders::TokenEncoder;
+    use crate::encoders::unified_encoder::UnifiedVocabEncoder;
     use crate::training::trainer::{BPETokenVocabTrainer, MergeJob, TrainResults};
     use crate::types::{check_is_send, check_is_sync};
     use crate::vocab::unified_vocab::UnifiedTokenVocab;

--- a/crates/bpetok/src/training/word.rs
+++ b/crates/bpetok/src/training/word.rs
@@ -3,7 +3,7 @@
 use crate::types::{Pair, TokenType};
 use core::hash::Hash;
 
-/// A word in a BPE-based tokenizer.
+/// A word in a BPE-based encoders.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Word<T: TokenType> {
     tokens: Vec<T>,

--- a/crates/bpetok/src/types.rs
+++ b/crates/bpetok/src/types.rs
@@ -4,7 +4,7 @@ use num_traits::{FromPrimitive, Num, ToPrimitive, Unsigned};
 use std::fmt::{Debug, Display};
 use std::ops::{AddAssign, SubAssign};
 
-/// A type that can be used as a token in a BPE-based tokenizer.
+/// A type that can be used as a token in a BPE-based encoders.
 pub trait TokenType:
     'static
     + Default

--- a/crates/bpetok/src/vocab/unified_vocab.rs
+++ b/crates/bpetok/src/vocab/unified_vocab.rs
@@ -1,6 +1,6 @@
 //! # Unified Vocabulary Data
 
-use crate::decoder::dictionary_decoder::DictionaryDecoder;
+use crate::decoders::dictionary_decoder::DictionaryDecoder;
 use crate::types::TokenType;
 use crate::util::regex::regex_wrapper::RegexWrapperPattern;
 use crate::vocab::pair_vocab::PairMapTokenVocab;
@@ -110,7 +110,7 @@ impl<T: TokenType> UnifiedTokenVocab<T> {
         dictionary
     }
 
-    /// Compile the unified vocabulary into a dictionary decoder.
+    /// Compile the unified vocabulary into a dictionary decoders.
     pub fn to_decoder(&self) -> DictionaryDecoder<T> {
         DictionaryDecoder::new(self.compiled_dictionary())
     }

--- a/crates/bpetok/src/vocab/word_vocab.rs
+++ b/crates/bpetok/src/vocab/word_vocab.rs
@@ -1,7 +1,7 @@
 //! # Word Map Vocabulary Data
 
-use crate::decoder::pair_decoder::PairExpansionDecoder;
-use crate::decoder::token_decoder::TokenDecoder;
+use crate::decoders::pair_decoder::PairExpansionDecoder;
+use crate::decoders::token_decoder::TokenDecoder;
 use crate::types::{TokenType, WordToTokenMap};
 use crate::vocab::pair_vocab::PairMapTokenVocab;
 use crate::vocab::vocab_index::TokenVocabIndex;


### PR DESCRIPTION
…`, update modules, structs, tests, and comments for consistency.