### PR TITLE
Introduce `BYTES_PER_TOKEN_HINT` constant and enhance efficiency of context handling.

### DIFF
--- a/crates/bpetok/src/decoders/byte_decoder.rs
+++ b/crates/bpetok/src/decoders/byte_decoder.rs
@@ -63,7 +63,7 @@ mod tests {
         );
         tokens.extend_from_slice(&[256, 3000]);
 
-        let mut ctx = TokenDecodeContext::for_tokens(tokens, 2);
+        let mut ctx = TokenDecodeContext::for_tokens(tokens);
         assert!(!decoder.incremental_decode(&mut ctx));
 
         assert_eq!(ctx.buf, "hello world".as_bytes().to_vec());

--- a/crates/bpetok/src/decoders/decode_context.rs
+++ b/crates/bpetok/src/decoders/decode_context.rs
@@ -1,5 +1,6 @@
 //! # Decoder Context
 
+use crate::BYTES_PER_TOKEN_HINT;
 use crate::types::TokenType;
 
 /// Representation of a token decoding context.
@@ -14,11 +15,17 @@ pub struct TokenDecodeContext<T: TokenType> {
 
 impl<T: TokenType> TokenDecodeContext<T> {
     /// Creates a new decoding context.
-    pub fn for_tokens(
+    pub fn for_tokens(tokens: Vec<T>) -> Self {
+        Self::for_tokens_with_hint(tokens, BYTES_PER_TOKEN_HINT)
+    }
+
+    /// Creates a new decoding context.
+    pub fn for_tokens_with_hint(
         tokens: Vec<T>,
-        size_hint: usize,
+        bytes_per_token_hint: f64,
     ) -> Self {
-        let buf = Vec::with_capacity(tokens.len() * size_hint);
+        let capacity = tokens.len() as f64 * bytes_per_token_hint * 1.25;
+        let buf = Vec::with_capacity(capacity as usize);
         let mut stack = tokens;
         stack.reverse();
         Self { buf, stack }

--- a/crates/bpetok/src/decoders/token_decoder.rs
+++ b/crates/bpetok/src/decoders/token_decoder.rs
@@ -26,7 +26,7 @@ pub trait TokenDecoder<T: TokenType>: TokenVocabIndex<T> + Send + Sync {
         &self,
         tokens: S,
     ) -> TokenDecodeContext<T> {
-        let mut context = TokenDecodeContext::for_tokens(tokens.as_ref().to_vec(), 2);
+        let mut context = TokenDecodeContext::for_tokens(tokens.as_ref().to_vec());
         self.incremental_decode(&mut context);
         context
     }
@@ -96,7 +96,7 @@ mod tests {
         );
         tokens.extend_from_slice(&[256, 3000]);
 
-        let mut ctx = TokenDecodeContext::for_tokens(tokens, 2);
+        let mut ctx = TokenDecodeContext::for_tokens(tokens);
         assert!(!decoder.incremental_decode(&mut ctx));
 
         assert_eq!(ctx.buf, "hello world".as_bytes().to_vec());

--- a/crates/bpetok/src/encoders/token_encoder.rs
+++ b/crates/bpetok/src/encoders/token_encoder.rs
@@ -1,5 +1,6 @@
 //! # Token Encoder Trait
 
+use crate::BYTES_PER_TOKEN_HINT;
 use crate::encoders::text_segmentor::WordRef;
 use crate::types::TokenType;
 use crate::vocab::TokenVocabIndex;
@@ -40,7 +41,9 @@ pub trait TokenEncoder<T: TokenType>: TokenVocabIndex<T> + Send + Sync {
         text: S,
     ) -> Vec<T> {
         let text = text.as_ref();
-        let mut tokens = Vec::with_capacity(text.len());
+        let capacity = text.len() as f64 / (BYTES_PER_TOKEN_HINT * 0.5);
+        let mut tokens = Vec::with_capacity(capacity as usize);
+
         self.encode_append(text, &mut tokens);
         tokens
     }

--- a/crates/bpetok/src/lib.rs
+++ b/crates/bpetok/src/lib.rs
@@ -19,3 +19,6 @@ pub const DEFAULT_PATTERN: &str = GPT4_PATTERN;
 pub const DEFAULT_PARALLEL: bool = true;
 #[cfg(not(feature = "rayon"))]
 pub const DEFAULT_PARALLEL: bool = false;
+
+/// Constant guess for the expected bytes/token ratio.
+pub const BYTES_PER_TOKEN_HINT: f64 = 4.0;


### PR DESCRIPTION


- Add `BYTES_PER_TOKEN_HINT` for better capacity estimations in encoding and decoding contexts.
- Refactor `TokenDecodeContext` to use hint-based buffer sizing.
- Improve tokenizer trainer's performance reporting with detailed byte/token metrics.