### PR TITLE
TrainingResult => UnifiedTokenVocab in trainer.

### DIFF
--- a/crates/wordchuck/README.md
+++ b/crates/wordchuck/README.md
@@ -30,6 +30,32 @@ See:
 
 - [examples/tokenizer_trainer](examples/tokenizer_trainer)
 
+# training example
+
+```rust,ignore
+    let vocab: Arc<UnifiedTokenVocab<T>> =
+        BinaryPairVocabTrainer::new_with_vocab_size(args.vocab_size)
+            .train_vocab_from_sample_iter::<T, K, C, _>(samples)
+            .expect("training failed")
+            .extend_word_vocab_from_pair_vocab()
+            .into();
+
+    let training_duration = std::time::Instant::now().duration_since(t0);
+    println!("- training_duration: {:#?}", training_duration);
+    println!("- vocab_size: {:#?}", vocab.max_token());
+    
+    if let Some(path) = args.tiktoken_save_path {
+        vocab.word_vocab.save_to_tiktoken_path(&path)?;
+        println!("- tiktoken vocab: {path:?}");
+    }
+
+    let encoder: UnifiedVocabEncoder<T> = UnifiedVocabEncoder::<T>::new(vocab.clone());
+    let encoder = ParallelEncoder::new(encoder);
+
+    let decoder = DictionaryDecoder::new(vocab.compiled_dictionary());
+    let decoder = ParallelDecoder::new(decoder);
+```
+
 # training and timing
 
 - Note: my machine is a beast (64-core Threadripper; NVME data disk).

--- a/crates/wordchuck/src/decoders/dictionary_decoder.rs
+++ b/crates/wordchuck/src/decoders/dictionary_decoder.rs
@@ -53,7 +53,7 @@ mod tests {
     use super::*;
     use crate::encoders::token_encoder::TokenEncoder;
     use crate::encoders::unified_encoder::UnifiedVocabEncoder;
-    use crate::training::trainer::{BinaryPairVocabTrainer, TrainResults};
+    use crate::training::trainer::BinaryPairVocabTrainer;
     use crate::types::{check_is_send, check_is_sync};
     use crate::vocab::unified_vocab::UnifiedTokenVocab;
     use alloc::sync::Arc;
@@ -73,15 +73,9 @@ mod tests {
             "it's not the heat, it's the salt",
         ];
 
-        let TrainResults {
-            word_pattern,
-            pair_vocab,
-        } = options
+        let vocab: Arc<UnifiedTokenVocab<T>> = options
             .train_vocab_from_sample_iter::<T, K, C, _>(samples.iter())
-            .unwrap();
-
-        let vocab: Arc<UnifiedTokenVocab<T>> = UnifiedTokenVocab::new(word_pattern.into())
-            .with_pair_vocab(pair_vocab)
+            .expect("training vocab should succeed")
             .into();
 
         let encoder = UnifiedVocabEncoder::<T>::new(vocab.clone());

--- a/crates/wordchuck/src/decoders/pair_decoder.rs
+++ b/crates/wordchuck/src/decoders/pair_decoder.rs
@@ -64,7 +64,7 @@ mod tests {
     use super::*;
     use crate::encoders::token_encoder::TokenEncoder;
     use crate::encoders::unified_encoder::UnifiedVocabEncoder;
-    use crate::training::trainer::{BinaryPairVocabTrainer, TrainResults};
+    use crate::training::trainer::BinaryPairVocabTrainer;
     use crate::types::{check_is_send, check_is_sync};
     use crate::vocab::unified_vocab::UnifiedTokenVocab;
     use alloc::sync::Arc;
@@ -84,15 +84,9 @@ mod tests {
             "it's not the heat, it's the salt",
         ];
 
-        let TrainResults {
-            word_pattern,
-            pair_vocab,
-        } = options
+        let vocab: Arc<UnifiedTokenVocab<T>> = options
             .train_vocab_from_sample_iter::<T, K, C, _>(samples.iter())
-            .unwrap();
-
-        let vocab: Arc<UnifiedTokenVocab<T>> = UnifiedTokenVocab::new(word_pattern.into())
-            .with_pair_vocab(pair_vocab)
+            .unwrap()
             .into();
 
         let encoder = UnifiedVocabEncoder::<T>::new(vocab.clone());

--- a/crates/wordchuck/src/decoders/parallel_decoder.rs
+++ b/crates/wordchuck/src/decoders/parallel_decoder.rs
@@ -76,7 +76,7 @@ mod tests {
     use crate::decoders::DictionaryDecoder;
     use crate::encoders::UnifiedVocabEncoder;
     use crate::encoders::token_encoder::TokenEncoder;
-    use crate::training::trainer::{BinaryPairVocabTrainer, TrainResults};
+    use crate::training::trainer::BinaryPairVocabTrainer;
     use crate::types::{check_is_send, check_is_sync};
     use crate::vocab::unified_vocab::UnifiedTokenVocab;
     use alloc::sync::Arc;
@@ -97,15 +97,9 @@ mod tests {
             "it's not the heat, it's the salt",
         ];
 
-        let TrainResults {
-            word_pattern,
-            pair_vocab,
-        } = options
+        let vocab: Arc<UnifiedTokenVocab<T>> = options
             .train_vocab_from_sample_iter::<T, K, C, _>(samples.iter())
-            .unwrap();
-
-        let vocab: Arc<_> = UnifiedTokenVocab::new(word_pattern.into())
-            .with_pair_vocab(pair_vocab)
+            .unwrap()
             .into();
 
         let encoder = UnifiedVocabEncoder::<T>::new(vocab.clone());

--- a/crates/wordchuck/src/encoders/parallel_encoder.rs
+++ b/crates/wordchuck/src/encoders/parallel_encoder.rs
@@ -90,10 +90,9 @@ where
 mod tests {
     use crate::decoders::TokenDecoder;
     use crate::encoders::{ParallelEncoder, TokenEncoder, UnifiedVocabEncoder};
-    use crate::training::{BinaryPairVocabTrainer, TrainResults};
+    use crate::training::BinaryPairVocabTrainer;
     use crate::types::{check_is_send, check_is_sync};
-    use crate::vocab::{TokenVocabIndex, UnifiedTokenVocab};
-    use alloc::sync::Arc;
+    use crate::vocab::TokenVocabIndex;
     use compact_str::CompactString;
 
     #[test]
@@ -110,21 +109,15 @@ mod tests {
             "it's not the heat, it's the salt",
         ];
 
-        let TrainResults {
-            word_pattern,
-            pair_vocab,
-        } = options
+        let mut vocab = options
             .train_vocab_from_sample_iter::<T, K, C, _>(samples.iter())
             .unwrap();
-
-        let mut vocab: UnifiedTokenVocab<T> =
-            UnifiedTokenVocab::new(word_pattern.into()).with_pair_vocab(pair_vocab);
 
         vocab.specials_vocab_mut().add_str_word("<|HI|>", 3000);
 
         let special_sample = "hello <|HI|> world";
 
-        let encoder = UnifiedVocabEncoder::<T>::new(Arc::new(vocab));
+        let encoder = UnifiedVocabEncoder::<T>::new(vocab.into());
         check_is_send(&encoder);
         check_is_sync(&encoder);
 

--- a/crates/wordchuck/src/encoders/unified_encoder.rs
+++ b/crates/wordchuck/src/encoders/unified_encoder.rs
@@ -123,10 +123,9 @@ mod tests {
     use crate::decoders::token_decoder::TokenDecoder;
     use crate::encoders::token_encoder::TokenEncoder;
     use crate::encoders::unified_encoder::UnifiedVocabEncoder;
-    use crate::training::trainer::{BinaryPairVocabTrainer, TrainResults};
+    use crate::training::trainer::BinaryPairVocabTrainer;
     use crate::types::{check_is_send, check_is_sync};
     use crate::vocab::TokenVocabIndex;
-    use crate::vocab::unified_vocab::UnifiedTokenVocab;
     use alloc::sync::Arc;
     use compact_str::CompactString;
 
@@ -144,15 +143,9 @@ mod tests {
             "it's not the heat, it's the salt",
         ];
 
-        let TrainResults {
-            word_pattern,
-            pair_vocab,
-        } = options
+        let mut vocab = options
             .train_vocab_from_sample_iter::<T, K, C, _>(samples.iter())
             .unwrap();
-
-        let mut vocab: UnifiedTokenVocab<T> =
-            UnifiedTokenVocab::new(word_pattern.into()).with_pair_vocab(pair_vocab);
 
         vocab.specials_vocab_mut().add_str_word("<|HI|>", 3000);
 

--- a/crates/wordchuck/src/training/mod.rs
+++ b/crates/wordchuck/src/training/mod.rs
@@ -5,4 +5,4 @@ pub mod trainer;
 pub mod word;
 pub mod word_count;
 
-pub use trainer::{BinaryPairVocabTrainer, TrainResults};
+pub use trainer::BinaryPairVocabTrainer;

--- a/crates/wordchuck/src/vocab/pair_vocab.rs
+++ b/crates/wordchuck/src/vocab/pair_vocab.rs
@@ -21,6 +21,11 @@ impl<T: TokenType> PairMapTokenVocab<T> {
     ) {
         self.pairs.insert(pair, token);
     }
+
+    /// Shrinks the capacity of the underlying data structures to fit its current size.
+    pub fn shrink_to_fit(&mut self) {
+        self.pairs.shrink_to_fit();
+    }
 }
 
 impl<T: TokenType> TokenVocabIndex<T> for PairMapTokenVocab<T> {

--- a/crates/wordchuck/src/vocab/unified_vocab.rs
+++ b/crates/wordchuck/src/vocab/unified_vocab.rs
@@ -59,10 +59,16 @@ impl<T: TokenType> UnifiedTokenVocab<T> {
         }
     }
 
+    /// Shrinks the capacity of the underlying data structures to fit its current size.
+    pub fn shrink_to_fit(&mut self) {
+        self.pair_vocab.shrink_to_fit();
+        self.word_vocab.shrink_to_fit();
+    }
+
     /// Materialize the tokens in the `pair_vocab` into the `word_vocab`.
     ///
     /// Leaves tokens which already exist in the `word_vocab`.
-    pub fn expand_words_from_bpe(self) -> Self {
+    pub fn extend_word_vocab_from_pair_vocab(self) -> Self {
         let mut word_vocab = self.word_vocab;
 
         let tokens: AHashSet<T> = word_vocab.compound_tokens_iter().collect();
@@ -104,7 +110,7 @@ impl<T: TokenType> UnifiedTokenVocab<T> {
     pub fn compiled_dictionary(&self) -> AHashMap<T, Vec<u8>> {
         let mut dictionary: AHashMap<T, Vec<u8>> = self
             .clone()
-            .expand_words_from_bpe()
+            .extend_word_vocab_from_pair_vocab()
             .word_vocab
             .words
             .into_iter()

--- a/crates/wordchuck/src/vocab/word_vocab.rs
+++ b/crates/wordchuck/src/vocab/word_vocab.rs
@@ -25,6 +25,11 @@ pub struct WordMapTokenVocab<T: TokenType> {
 }
 
 impl<T: TokenType> WordMapTokenVocab<T> {
+    /// Shrinks the capacity of the underlying data structures to fit its current size.
+    pub fn shrink_to_fit(&mut self) {
+        self.words.shrink_to_fit();
+    }
+
     /// Load a tiktoken vocab file into a [`WordToTokenMap`].
     pub fn load_from_tiktoken_path<P: AsRef<Path>>(path: P) -> anyhow::Result<Self> {
         let mut vocab = WordMapTokenVocab::default();


### PR DESCRIPTION
Refactor training pipeline to simplify `UnifiedTokenVocab` usage, replace `TrainResults` with direct vocab returns, and add `shrink_to_fit` support for vocab structures.