### PR TITLE
Add iterator implementations and utility methods for vocabularies

### DIFF
--- a/crates/wordchuck/src/vocab/pair_vocab.rs
+++ b/crates/wordchuck/src/vocab/pair_vocab.rs
@@ -12,7 +12,30 @@ pub struct PairMapTokenVocab<T: TokenType> {
     pub pairs: PairToTokenMap<T>,
 }
 
+impl<'a, T: TokenType> IntoIterator for &'a PairMapTokenVocab<T> {
+    type Item = (&'a (T, T), &'a T);
+    type IntoIter = std::collections::hash_map::Iter<'a, (T, T), T>;
+    fn into_iter(self) -> Self::IntoIter {
+        self.pairs.iter()
+    }
+}
+
 impl<T: TokenType> PairMapTokenVocab<T> {
+    /// The number of words in the vocabulary.
+    pub fn len(&self) -> usize {
+        self.pairs.len()
+    }
+
+    /// Returns `true` if the vocabulary contains no words.
+    pub fn is_empty(&self) -> bool {
+        self.pairs.is_empty()
+    }
+
+    /// Iterate over the pairs in the vocabulary.
+    pub fn iter<'a>(&'a self) -> impl Iterator<Item = (&'a (T, T), &'a T)> + 'a {
+        self.pairs.iter()
+    }
+
     /// Add a pair to the vocab.
     pub fn add_pair(
         &mut self,

--- a/crates/wordchuck/src/vocab/unified_vocab.rs
+++ b/crates/wordchuck/src/vocab/unified_vocab.rs
@@ -112,9 +112,8 @@ impl<T: TokenType> UnifiedTokenVocab<T> {
             .clone()
             .extend_word_vocab_from_pair_vocab()
             .word_vocab
-            .words
-            .into_iter()
-            .map(|(chunk, token)| (token, chunk))
+            .iter()
+            .map(|(chunk, &token)| (token, chunk.to_vec()))
             .collect();
 
         if let Some(specials) = &self.specials {

--- a/crates/wordchuck/src/vocab/word_vocab.rs
+++ b/crates/wordchuck/src/vocab/word_vocab.rs
@@ -24,10 +24,35 @@ pub struct WordMapTokenVocab<T: TokenType> {
     pub words: WordToTokenMap<T>,
 }
 
+impl<'a, T: TokenType> IntoIterator for &'a WordMapTokenVocab<T> {
+    type Item = (&'a Vec<u8>, &'a T);
+
+    type IntoIter = std::collections::hash_map::Iter<'a, Vec<u8>, T>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.words.iter()
+    }
+}
+
 impl<T: TokenType> WordMapTokenVocab<T> {
     /// Shrinks the capacity of the underlying data structures to fit its current size.
     pub fn shrink_to_fit(&mut self) {
         self.words.shrink_to_fit();
+    }
+
+    /// The number of words in the vocabulary.
+    pub fn len(&self) -> usize {
+        self.words.len()
+    }
+
+    /// Returns `true` if the vocabulary contains no words.
+    pub fn is_empty(&self) -> bool {
+        self.words.is_empty()
+    }
+
+    /// Iterate over the words in the vocabulary.
+    pub fn iter<'a>(&'a self) -> impl Iterator<Item = (&'a Vec<u8>, &'a T)> + 'a {
+        self.words.iter()
     }
 
     /// Load a tiktoken vocab file into a [`WordToTokenMap`].


### PR DESCRIPTION
Introduce `IntoIterator` implementations and utility methods (`len`, `is_empty`, `iter`) for `WordMapTokenVocab` and `PairMapTokenVocab` to improve usability and iteration support. Optimize `UnifiedTokenVocab` processing by switching to `.iter()`.