### PR TITLE
Refactor IO paths / vocab conversion.

### DIFF
--- a/crates/wordchuck/examples/tokenizer_trainer/src/main.rs
+++ b/crates/wordchuck/examples/tokenizer_trainer/src/main.rs
@@ -9,6 +9,7 @@ use std::time::Duration;
 use wordchuck::decoders::{DictionaryDecoder, ParallelDecoder, TokenDecoder};
 use wordchuck::encoders::{ParallelEncoder, TokenEncoder, UnifiedVocabEncoder};
 use wordchuck::training::BinaryPairVocabTrainer;
+use wordchuck::vocab::io::tiktoken::save_word_map_to_tiktoken_path;
 use wordchuck::vocab::{TokenVocabIndex, UnifiedTokenVocab};
 
 /// Example encoders trainer.
@@ -126,9 +127,10 @@ fn main() -> anyhow::Result<()> {
     println!("- vocab_size: {:#?}", vocab.max_token());
 
     if let Some(path) = args.tiktoken_save_path {
-        vocab.word_vocab.save_to_tiktoken_path(&path)?;
+        save_word_map_to_tiktoken_path(&vocab.word_vocab, &path)?;
         println!("- tiktoken vocab: {path:?}");
     }
+
     if args.time_encode_decode {
         let encoder: UnifiedVocabEncoder<T> = UnifiedVocabEncoder::<T>::new(vocab.clone());
         let encoder = ParallelEncoder::new(encoder);

--- a/crates/wordchuck/examples/tokenizer_trainer/src/main.rs
+++ b/crates/wordchuck/examples/tokenizer_trainer/src/main.rs
@@ -9,7 +9,7 @@ use std::time::Duration;
 use wordchuck::decoders::{DictionaryDecoder, ParallelDecoder, TokenDecoder};
 use wordchuck::encoders::{ParallelEncoder, TokenEncoder, UnifiedVocabEncoder};
 use wordchuck::training::BinaryPairVocabTrainer;
-use wordchuck::vocab::io::tiktoken::save_word_map_to_tiktoken_path;
+use wordchuck::vocab::io::tiktoken_io::save_word_map_to_tiktoken_path;
 use wordchuck::vocab::{TokenVocabIndex, UnifiedTokenVocab};
 
 /// Example encoders trainer.

--- a/crates/wordchuck/src/vocab/io/mod.rs
+++ b/crates/wordchuck/src/vocab/io/mod.rs
@@ -1,3 +1,3 @@
 //! # Vocabulary IO
 
-pub mod tiktoken;
+pub mod tiktoken_io;

--- a/crates/wordchuck/src/vocab/io/mod.rs
+++ b/crates/wordchuck/src/vocab/io/mod.rs
@@ -1,0 +1,3 @@
+//! # Vocabulary IO
+
+pub mod tiktoken;

--- a/crates/wordchuck/src/vocab/io/tiktoken.rs
+++ b/crates/wordchuck/src/vocab/io/tiktoken.rs
@@ -1,0 +1,96 @@
+//! # Tiktoken Vocabulary IO
+
+use crate::types::TokenType;
+use crate::vocab::WordMapTokenVocab;
+use anyhow::Context;
+use base64::Engine;
+use base64::prelude::BASE64_STANDARD;
+use std::io::{BufRead, BufReader, BufWriter, Write};
+use std::path::Path;
+
+/// Load a [`WordMapTokenVocab`] from a tiktoken vocab file.
+///
+/// # Arguments
+/// * `path` - the path to the vocabulary file.
+pub fn load_word_map_from_tiktoken_path<T: TokenType, P: AsRef<Path>>(
+    path: P
+) -> anyhow::Result<WordMapTokenVocab<T>> {
+    let file = std::fs::File::open(path)?;
+    let reader = BufReader::new(file);
+    let mut vocab = WordMapTokenVocab::default();
+
+    for line in reader.lines() {
+        let line = line?;
+        let s: &str = line.as_ref();
+
+        let parts = s.splitn(2, ' ').collect::<Vec<&str>>();
+        assert_eq!(parts.len(), 2);
+
+        let chunk = parts[0];
+        let chunk = BASE64_STANDARD.decode(chunk)?;
+
+        let token: u64 = parts[1].parse()?;
+        let token = T::from_u64(token).context("token out of range")?;
+
+        vocab.add_bytes_word(chunk, token);
+    }
+    Ok(vocab)
+}
+
+/// Save a [`WordMapTokenVocab`] to a tiktoken vocab file.
+///
+/// # Arguments
+/// * `vocab` - the vocabulary to save.
+/// * `path` - the path to save the vocabulary to.
+pub fn save_word_map_to_tiktoken_path<T: TokenType, P: AsRef<Path>>(
+    vocab: &WordMapTokenVocab<T>,
+    path: P,
+) -> anyhow::Result<()> {
+    let file = std::fs::File::create(path)?;
+    let mut writer = BufWriter::new(file);
+
+    let mut items: Vec<(T, &Vec<u8>)> =
+        vocab.iter().map(|(chunk, &token)| (token, chunk)).collect();
+    items.sort_by_key(|(t, _)| *t);
+
+    for (token, chunk) in items {
+        writeln!(
+            writer,
+            "{} {}",
+            BASE64_STANDARD.encode(chunk),
+            token.to_u64().unwrap()
+        )?;
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_save_load_tiktoken() {
+        type T = u32;
+
+        let mut vocab = WordMapTokenVocab::<T>::default();
+        vocab.add_str_word("apple", 300);
+        vocab.add_str_word("banana", 301);
+        vocab.add_str_word("pear", 302);
+
+        tempdir::TempDir::new("vocab_test")
+            .and_then(|dir| {
+                let path = dir.path().join("vocab.tiktoken");
+
+                save_word_map_to_tiktoken_path(&vocab, &path).expect("Failed to save vocab");
+
+                let loaded_vocab =
+                    load_word_map_from_tiktoken_path(&path).expect("Failed to load vocab");
+
+                assert_eq!(&vocab, &loaded_vocab);
+
+                Ok(())
+            })
+            .unwrap();
+    }
+}

--- a/crates/wordchuck/src/vocab/mod.rs
+++ b/crates/wordchuck/src/vocab/mod.rs
@@ -1,5 +1,6 @@
 //! # Vocabulary
 
+pub mod io;
 pub mod pair_vocab;
 pub mod unified_vocab;
 pub mod vocab_index;

--- a/crates/wordchuck/src/vocab/unified_vocab.rs
+++ b/crates/wordchuck/src/vocab/unified_vocab.rs
@@ -6,7 +6,7 @@ use crate::util::regex::RegexWrapperPattern;
 use crate::vocab::pair_vocab::PairMapTokenVocab;
 use crate::vocab::vocab_index::TokenVocabIndex;
 use crate::vocab::word_vocab::WordMapTokenVocab;
-use ahash::{AHashMap, AHashSet};
+use ahash::AHashMap;
 
 /// Unified token vocabulary.
 #[derive(Clone)]
@@ -70,14 +70,7 @@ impl<T: TokenType> UnifiedTokenVocab<T> {
     /// Leaves tokens which already exist in the `word_vocab`.
     pub fn extend_word_vocab_from_pair_vocab(self) -> Self {
         let mut word_vocab = self.word_vocab;
-
-        let tokens: AHashSet<T> = word_vocab.compound_tokens_iter().collect();
-
-        for (w, t) in WordMapTokenVocab::from_pair_vocab(&self.pair_vocab).words {
-            if !tokens.contains(&t) {
-                word_vocab.words.insert(w, t);
-            }
-        }
+        word_vocab.extend_from_pair_vocab(&self.pair_vocab, false);
 
         Self { word_vocab, ..self }
     }

--- a/crates/wordchuck/src/vocab/word_vocab.rs
+++ b/crates/wordchuck/src/vocab/word_vocab.rs
@@ -5,13 +5,8 @@ use crate::decoders::token_decoder::TokenDecoder;
 use crate::types::{TokenType, WordToTokenMap};
 use crate::vocab::pair_vocab::PairMapTokenVocab;
 use crate::vocab::vocab_index::TokenVocabIndex;
-use ahash::AHashMap;
-use anyhow::Context;
-use base64::Engine;
-use base64::prelude::BASE64_STANDARD;
+use ahash::{AHashMap, AHashSet};
 use serde::{Deserialize, Serialize};
-use std::io::{BufRead, BufReader, BufWriter, Write};
-use std::path::Path;
 
 /// Token vocabulary as a dictionary map of ``{ Vec<u8> -> T }``.
 #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -19,8 +14,6 @@ use std::path::Path;
 pub struct WordMapTokenVocab<T: TokenType> {
     /// The regex pattern used for text spl
     /// Map of ``{ &[u8] -> T }``.
-    ///
-    /// Words in this map take priority over the `binary_pair_map`.
     pub words: WordToTokenMap<T>,
 }
 
@@ -55,85 +48,22 @@ impl<T: TokenType> WordMapTokenVocab<T> {
         self.words.iter()
     }
 
-    /// Load a tiktoken vocab file into a [`WordToTokenMap`].
-    pub fn load_from_tiktoken_path<P: AsRef<Path>>(path: P) -> anyhow::Result<Self> {
-        let mut vocab = WordMapTokenVocab::default();
-
-        let file = std::fs::File::open(path)?;
-        let reader = BufReader::new(file);
-        for line in reader.lines() {
-            let line: String = line?;
-            let s = line.as_str();
-
-            let parts = s.splitn(2, ' ').collect::<Vec<&str>>();
-            assert_eq!(parts.len(), 2);
-
-            let chunk = parts[0];
-            let chunk = BASE64_STANDARD.decode(chunk)?;
-
-            let token: u64 = parts[1].parse()?;
-            let token = T::from_u64(token).context("token out of range")?;
-
-            vocab.add_bytes_word(&chunk, token);
-        }
-        Ok(vocab)
-    }
-
-    /// Save this vocab to a tiktoken vocab file.
-    pub fn save_to_tiktoken_path<P: AsRef<Path>>(
-        &self,
-        path: P,
-    ) -> anyhow::Result<()> {
-        let file = std::fs::File::create(path)?;
-        let mut writer = BufWriter::new(file);
-
-        let mut items: Vec<(T, &Vec<u8>)> = self
-            .words
-            .iter()
-            .map(|(chunk, &token)| (token, chunk))
-            .collect();
-        items.sort_by_key(|(t, _)| *t);
-
-        for (token, chunk) in items {
-            writeln!(
-                writer,
-                "{} {}",
-                BASE64_STANDARD.encode(chunk),
-                token.to_u64().unwrap()
-            )?;
-        }
-
-        Ok(())
-    }
-
     /// Add a word to the vocab.
     pub fn add_str_word(
         &mut self,
         word: &str,
         token: T,
     ) {
-        self.add_bytes_word(word.as_bytes(), token);
+        self.add_bytes_word(word.as_bytes().to_vec(), token);
     }
 
     /// Add a word to the vocab.
     pub fn add_bytes_word(
         &mut self,
-        word: &[u8],
+        word: Vec<u8>,
         token: T,
     ) {
-        self.words.insert(word.to_vec(), token);
-    }
-
-    /// Build word vocabulary from a BPE map vocabulary.
-    pub fn from_pair_vocab(pair_vocab: &PairMapTokenVocab<T>) -> Self {
-        let decoder = PairExpansionDecoder::from_pair_map(&pair_vocab.pairs);
-        let mut words = WordToTokenMap::default();
-        for token in pair_vocab.compound_tokens_iter() {
-            let tokens = [token];
-            let chunk = decoder.try_decode_to_bytes(tokens).unwrap();
-            words.insert(chunk, token);
-        }
-        Self { words }
+        self.words.insert(word, token);
     }
 
     /// Return the associated token for the word, if any.
@@ -153,8 +83,45 @@ impl<T: TokenType> WordMapTokenVocab<T> {
         }
     }
 
+    /// Build word vocabulary from a [`PairMapTokenVocab<T>`].
+    pub fn from_pair_vocab(pair_vocab: &PairMapTokenVocab<T>) -> Self {
+        let mut vocab = Self::default();
+        vocab.extend_from_pair_vocab(pair_vocab, true);
+        vocab
+    }
+
+    /// Extend the word vocabulary from a BPE map vocabulary.
+    ///
+    /// # Arguments
+    /// * `pair_vocab` - the source pair vocab.
+    /// * `overwrite` - whether to overwrite existing entries in the word vocab.
+    pub fn extend_from_pair_vocab(
+        &mut self,
+        pair_vocab: &PairMapTokenVocab<T>,
+        overwrite: bool,
+    ) {
+        let skip: Option<AHashSet<T>> = if overwrite {
+            None
+        } else {
+            Some(self.compound_tokens_iter().collect())
+        };
+
+        let decoder = PairExpansionDecoder::from_pair_map(&pair_vocab.pairs);
+        for token in pair_vocab.compound_tokens_iter() {
+            if let Some(skip) = &skip
+                && skip.contains(&token)
+            {
+                continue;
+            }
+
+            let tokens = [token];
+            let chunk = decoder.try_decode_to_bytes(tokens).unwrap();
+            self.add_bytes_word(chunk, token);
+        }
+    }
+
     /// Build a binary pair map from the word vocabulary.
-    pub fn build_pair_vocab(&self) -> PairMapTokenVocab<T> {
+    pub fn to_pair_vocab(&self) -> PairMapTokenVocab<T> {
         let mut pair_vocab = PairMapTokenVocab::<T>::default();
 
         let token_to_words: AHashMap<T, &[u8]> = self
@@ -179,6 +146,18 @@ impl<T: TokenType> WordMapTokenVocab<T> {
         }
 
         pair_vocab
+    }
+}
+
+impl<T: TokenType> From<&PairMapTokenVocab<T>> for WordMapTokenVocab<T> {
+    fn from(pair_vocab: &PairMapTokenVocab<T>) -> Self {
+        Self::from_pair_vocab(pair_vocab)
+    }
+}
+
+impl<T: TokenType> From<&WordMapTokenVocab<T>> for PairMapTokenVocab<T> {
+    fn from(vocab: &WordMapTokenVocab<T>) -> Self {
+        vocab.to_pair_vocab()
     }
 }
 
@@ -235,33 +214,6 @@ mod tests {
     }
 
     #[test]
-    fn test_save_load_tiktoken() {
-        type T = u32;
-
-        let mut vocab = WordMapTokenVocab::<T>::default();
-        vocab.add_str_word("apple", 300);
-        vocab.add_str_word("banana", 301);
-        vocab.add_str_word("pear", 302);
-
-        tempdir::TempDir::new("vocab_test")
-            .and_then(|dir| {
-                let path = dir.path().join("vocab.tiktoken");
-
-                vocab
-                    .save_to_tiktoken_path(&path)
-                    .expect("Failed to save vocab");
-
-                let loaded_vocab = WordMapTokenVocab::<T>::load_from_tiktoken_path(&path)
-                    .expect("Failed to load vocab");
-
-                assert_eq!(&vocab, &loaded_vocab);
-
-                Ok(())
-            })
-            .unwrap();
-    }
-
-    #[test]
     fn test_lookup_token() {
         type T = u32;
         let mut vocab = WordMapTokenVocab::<T>::default();
@@ -281,7 +233,7 @@ mod tests {
         vocab.add_str_word("ate", 301);
         vocab.add_str_word("cat", 302);
 
-        let pair_vocab = vocab.build_pair_vocab();
+        let pair_vocab = vocab.to_pair_vocab();
         assert_eq!(
             &pair_vocab.pairs,
             &[


### PR DESCRIPTION
Extract TikToken IO logic into a dedicated module and add support for extending vocabularies (#39)

Move TikToken save/load logic from `WordMapTokenVocab` to a new `io` module for cleaner separation of concerns. Introduce methods for extending vocabularies (`extend_from_pair_vocab`) with optional overwrite, and add `From` implementations to support conversions between `WordMapTokenVocab` and `PairMapTokenVocab`. Replace vocabulary save/load usage in examples with new `io` helpers.