### PR TITLE
Refactor trainer, update docs.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5179,7 +5179,7 @@ dependencies = [
 
 [[package]]
 name = "nanochat"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
  "anyhow",
  "bimm-contracts",
@@ -5188,7 +5188,7 @@ dependencies = [
 
 [[package]]
 name = "nanochat-data"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
  "anyhow",
  "burn 0.20.0-pre.6",
@@ -8609,7 +8609,7 @@ checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 
 [[package]]
 name = "wordchuck"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
  "ahash",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.0.2"
+version = "0.0.3"
 repository = "https://github.com/crutcher/brn-nanochat"
 rust-version = "1.90.0"
 edition = "2024"

--- a/crates/wordchuck/examples/tokenizer_trainer/README.md
+++ b/crates/wordchuck/examples/tokenizer_trainer/README.md
@@ -2,90 +2,51 @@
 
 Each shard is ~90MB parquet file.
 
-```terminaloutput
-$ cargo run --release -p pull -- --dataset-dir /media/data/nanochat/dataset --shards ..8
-```
-
-# nanochat-equivalent tokenizer train
-
-_TL;DR_:
-
-    I think 2**16 vocab size is a bad choice for nanochat.
-    It was picked arbitrarily, without tracing out the full tuning.
-
-    It should either be smaller (to reserve space for meta tokens),
-    and actually use that size to reduce memory costs / vector sizes.
-
-    Or, we should search over larger sizes.
-
-This is a *partial example* of training a nanochat-equivalent tokenizer:
-
-- we don't support export / load of the tokenizer yet; so this is all in-memory for nothing.
-- the nanochat choice of 2**16 vocab size *seems* cool; but it ignores:
-    - nighter the `rustbpe` nor `tiktoken` tokenizers support tuning the `Token` width for a smaller vocab size.
-    - the token=>embedding table also doesn't tune for smaller vocab sizes.
-
-See: [original nanochat/speedrun.sh](https://github.com/karpathy/nanochat/blob/master/speedrun.sh#L58C1-L69C51)
-
-```bash
-# Download the first ~2B characters of pretraining dataset
-# look at dev/repackage_data_reference.py for details on how this data was prepared
-# each data shard is ~250M chars
-# so we download 2e9 / 250e6 = 8 data shards at this point
-# each shard is ~100MB of text (compressed), so this is about ~800MB of data on disk
-python -m nanochat.dataset -n 8
-# Immediately also kick off downloading more shards in the background while encoders trains
-# See comment below for why 240 is the right number here
-python -m nanochat.dataset -n 240 &
-DATASET_DOWNLOAD_PID=$!
-# train the encoders with vocab size 2**16 = 65536 on ~2B characters of data
-python -m scripts.tok_train --max_chars=2000000000
-```
-
-# training and timing
-
-- Note: my machine is a beast (64-core Threadripper; NVME data disk).
+- 128/64 Core Thread Ripper
 
 ```terminaloutput
-$ time cargo run --release -p tokenizer_trainer -- --dataset-dir /media/Data/nanochat/dataset --shards ..8 --vocab-size=65536 --time-encode-decode --batch-size 512 --num-timing-batches 60
-   Compiling tokenizer_trainer v0.0.0 (/home/crutcher/git/brn-nanochat/crates/bpetok/examples/tokenizer_trainer)
-    Finished `release` profile [optimized] target(s) in 1.54s
-     Running `target/release/tokenizer_trainer --dataset-dir /media/Data/nanochat/dataset --shards ..8 --vocab-size=65536 --time-encode-decode --batch-size 512 --num-timing-batches 60`
-Loading Shards ...: [0, 1, 2, 3, 4, 5, 6, 7]
+$ time cargo run --release -p tokenizer_trainer -- --dataset-dir /media/Data/nanochat/dataset  --time-encode-decode 
+   Compiling tokenizer_trainer v0.0.0 (/home/crutcher/git/brn-nanochat/crates/wordchuck/examples/tokenizer_trainer)
+    Finished `release` profile [optimized] target(s) in 1.34s
+     Running `target/release/tokenizer_trainer --dataset-dir /media/Data/nanochat/dataset --time-encode-decode`
+Loading Shards: [0, 1, 2, 3, 4, 5, 6, 7]
+...
 
 Training Tokenizer on shards: [0, 1, 2, 3, 4, 5, 6, 7]
-- training_duration: 74.15810139s
+- shard: 0
+- shard: 1
+- shard: 2
+- shard: 3
+- shard: 4
+- shard: 5
+- shard: 6
+- shard: 7
+- train
+- training_duration: 220.05s
 - vocab_size: 65535
-- size_estimate: 917613
 
 Samples Summary:
-- count: 53248
-- avg size: 4783
+- count: 20480
+- avg size: 4741
 
 Timing Config:
 - batch size: 512
 
-Timing CPSEncoder Encode:
-- batch avg: 83.835533ms
-- sample avg: 163.741µs
-- avg bps: 29.21 MB/s
+Timing Encode:
+- batch avg: 69.918721ms
+- sample avg: 136.56µs
+- avg bps: 34.72 MB/s
 
-Timing Decode: ExpansionDecoder
-- decoder est bytes: 1566720
-- batch avg: 2.219528ms
-- sample avg: 4.335µs
+Observed Bytes/Token Stats:
+- total bytes: 97103222
+- total tokens: 24645141
+- sample byte/token: 3.94
 
-Timing Decode: DictionaryDecoder
-- decoder est bytes: 1860233
-- batch avg: 1.463183ms
-- sample avg: 2.857µs
+Timing Decode:
+- batch avg: 2.373206ms
+- sample avg: 4.635µs
 
-Timing Decode: CorpusDecoder
-- decoder est bytes: 1820714
-- batch avg: 1.485641ms
-- sample avg: 2.901µs
-
-real    1m26.091s
-user    86m4.472s
-sys     27m10.539s
+real    3m45.018s
+user    78m36.407s
+sys     37m53.941s
 ```

--- a/crates/wordchuck/src/decoders/mod.rs
+++ b/crates/wordchuck/src/decoders/mod.rs
@@ -4,10 +4,13 @@ pub mod byte_decoder;
 pub mod decode_context;
 pub mod dictionary_decoder;
 pub mod pair_decoder;
-pub mod parallel_decoder;
 pub mod token_decoder;
 
 pub use decode_context::TokenDecodeContext;
 pub use dictionary_decoder::DictionaryDecoder;
-pub use parallel_decoder::ParallelDecoder;
 pub use token_decoder::TokenDecoder;
+
+#[cfg(feature = "rayon")]
+pub mod rayon_decoder;
+#[cfg(feature = "rayon")]
+pub use rayon_decoder::ParallelRayonDecoder;

--- a/crates/wordchuck/src/encoders/mod.rs
+++ b/crates/wordchuck/src/encoders/mod.rs
@@ -1,11 +1,14 @@
 //! # Tokenizer Structures
 
 pub mod bp_merge;
-pub mod parallel_encoder;
 pub mod text_segmentor;
 pub mod token_encoder;
 pub mod unified_encoder;
 
-pub use parallel_encoder::ParallelEncoder;
 pub use token_encoder::TokenEncoder;
 pub use unified_encoder::UnifiedVocabEncoder;
+
+#[cfg(feature = "rayon")]
+pub mod rayon_encoder;
+#[cfg(feature = "rayon")]
+pub use rayon_encoder::ParallelRayonEncoder;

--- a/crates/wordchuck/src/lib.rs
+++ b/crates/wordchuck/src/lib.rs
@@ -7,21 +7,33 @@
 //! Consider the following, to train a tokenizer and export it a "*.tiktoken" file.
 //!
 //! - the iterator stream for samples may be quite large.
-//! - training a `nanochat` equivalent tokenizer takes ~150 CPU minutes.
+//! - training a `nanochat` equivalent tokenizer takes ~80 CPU minutes.
 //!
 //! ```rust,ignore
-//! let TrainResults::<T> {
-//!     word_pattern,
-//!     pair_vocab,
-//! } = BinaryPairVocabTrainer::new_with_vocab_size(args.vocab_size)
-//!     .train_vocab_from_sample_iter::<T, K, C, _>(samples)
-//!     .expect("training failed");
+//! let options = BinaryPairVocabTrainerOptions::new_with_vocab_size(args.vocab_size);
 //!
-//! let vocab: = UnifiedTokenVocab::new(word_pattern.into())
-//!     .with_pair_vocab(pair_vocab)
-//!     .expand_words_from_bpe();
+//! let mut trainer = options.init::<K, C>();
 //!
-//! encoder_data.word_vocab.save_to_tiktoken_path(&path)?;
+//! for batch in batches {
+//! trainer.update_from_sampples(batch.iter());
+//! }
+//!
+//! let vocab: Arc<UnifiedTokenVocab<T>> = trainer
+//! .train()
+//! .expect("training failed")
+//! .extend_word_vocab_from_pair_vocab()
+//! .into();
+//!
+//! if let Some(path) = args.tiktoken_save_path {
+//! vocab.word_vocab.save_to_tiktoken_path(&path)?;
+//! println!("- tiktoken vocab: {path:?}");
+//! }
+//!
+//! let encoder: UnifiedVocabEncoder<T> = UnifiedVocabEncoder::<T>::new(vocab.clone());
+//! let encoder = ParallelEncoder::new(encoder);
+//!
+//! let decoder = DictionaryDecoder::new(vocab.compiled_dictionary());
+//! let decoder = ParallelDecoder::new(decoder);
 //! ```
 #![warn(missing_docs, unused)]
 


### PR DESCRIPTION
Refactor tokenizer trainer to use `BinaryPairVocabTrainerOptions`, replace parallel encoder/decoder with rayon-based implementations, and update docs/examples for consistency