### PR TITLE
Update OpenAI patterns and add resource tooling

### DIFF
--- a/crates/wordchuck/examples/tokenizer_trainer/src/main.rs
+++ b/crates/wordchuck/examples/tokenizer_trainer/src/main.rs
@@ -10,7 +10,7 @@ use wordchuck::encoders::{TokenEncoder, UnifiedVocabEncoder};
 use wordchuck::rayon::{ParallelRayonDecoder, ParallelRayonEncoder};
 use wordchuck::training::BinaryPairVocabTrainerOptions;
 use wordchuck::vocab::io::tiktoken_io::save_word_map_to_tiktoken_path;
-use wordchuck::vocab::public::openai::patterns::GPT3_CL100K_WORD_PATTERN;
+use wordchuck::vocab::public::openai::patterns::OA_GPT3_CL100K_WORD_PATTERN;
 use wordchuck::vocab::{TokenVocabIndex, UnifiedTokenVocab};
 
 /// Example encoders trainer.
@@ -91,7 +91,7 @@ fn main() -> anyhow::Result<()> {
     let t0 = std::time::Instant::now();
 
     let vocab_size = args.vocab_size;
-    let options = BinaryPairVocabTrainerOptions::new(GPT3_CL100K_WORD_PATTERN, vocab_size);
+    let options = BinaryPairVocabTrainerOptions::new(OA_GPT3_CL100K_WORD_PATTERN, vocab_size);
 
     let mut trainer = options.init::<K, C>();
 

--- a/crates/wordchuck/src/decoders/dictionary_decoder.rs
+++ b/crates/wordchuck/src/decoders/dictionary_decoder.rs
@@ -55,7 +55,7 @@ mod tests {
     use crate::encoders::unified_encoder::UnifiedVocabEncoder;
     use crate::training::trainer::BinaryPairVocabTrainerOptions;
     use crate::types::{check_is_send, check_is_sync};
-    use crate::vocab::public::openai::patterns::GPT3_CL100K_WORD_PATTERN;
+    use crate::vocab::public::openai::patterns::OA_GPT3_CL100K_WORD_PATTERN;
     use crate::vocab::unified_vocab::UnifiedTokenVocab;
     use alloc::sync::Arc;
     use compact_str::CompactString;
@@ -66,7 +66,7 @@ mod tests {
         type C = u32;
         type K = CompactString;
 
-        let options = BinaryPairVocabTrainerOptions::new(GPT3_CL100K_WORD_PATTERN, 1000);
+        let options = BinaryPairVocabTrainerOptions::new(OA_GPT3_CL100K_WORD_PATTERN, 1000);
 
         let samples = vec![
             "hello world",

--- a/crates/wordchuck/src/decoders/pair_decoder.rs
+++ b/crates/wordchuck/src/decoders/pair_decoder.rs
@@ -66,7 +66,7 @@ mod tests {
     use crate::encoders::unified_encoder::UnifiedVocabEncoder;
     use crate::training::trainer::BinaryPairVocabTrainerOptions;
     use crate::types::{check_is_send, check_is_sync};
-    use crate::vocab::public::openai::patterns::GPT3_CL100K_WORD_PATTERN;
+    use crate::vocab::public::openai::patterns::OA_GPT3_CL100K_WORD_PATTERN;
     use crate::vocab::unified_vocab::UnifiedTokenVocab;
     use alloc::sync::Arc;
     use compact_str::CompactString;
@@ -77,7 +77,7 @@ mod tests {
         type C = u32;
         type K = CompactString;
 
-        let options = BinaryPairVocabTrainerOptions::new(GPT3_CL100K_WORD_PATTERN, 1000);
+        let options = BinaryPairVocabTrainerOptions::new(OA_GPT3_CL100K_WORD_PATTERN, 1000);
 
         let samples = vec![
             "hello world",

--- a/crates/wordchuck/src/encoders/text_segmentor.rs
+++ b/crates/wordchuck/src/encoders/text_segmentor.rs
@@ -129,12 +129,14 @@ impl TextSegmentor {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::vocab::public::openai::patterns::GPT3_CL100K_WORD_PATTERN;
+    use crate::vocab::public::openai::patterns::OA_GPT3_CL100K_WORD_PATTERN;
 
     #[test]
     fn test_split_words() {
-        let segmentor =
-            TextSegmentor::create(GPT3_CL100K_WORD_PATTERN, Some(&["<|FNORD|>", "<|NORP|>"]));
+        let segmentor = TextSegmentor::create(
+            OA_GPT3_CL100K_WORD_PATTERN,
+            Some(&["<|FNORD|>", "<|NORP|>"]),
+        );
 
         let buf = "hello<|FNORD|> wor<|NORP|>ld!";
 

--- a/crates/wordchuck/src/encoders/unified_encoder.rs
+++ b/crates/wordchuck/src/encoders/unified_encoder.rs
@@ -126,7 +126,7 @@ mod tests {
     use crate::training::trainer::BinaryPairVocabTrainerOptions;
     use crate::types::{check_is_send, check_is_sync};
     use crate::vocab::TokenVocabIndex;
-    use crate::vocab::public::openai::patterns::GPT3_CL100K_WORD_PATTERN;
+    use crate::vocab::public::openai::patterns::OA_GPT3_CL100K_WORD_PATTERN;
     use alloc::sync::Arc;
     use compact_str::CompactString;
 
@@ -136,7 +136,7 @@ mod tests {
         type C = u32;
         type K = CompactString;
 
-        let options = BinaryPairVocabTrainerOptions::new(GPT3_CL100K_WORD_PATTERN, 1000);
+        let options = BinaryPairVocabTrainerOptions::new(OA_GPT3_CL100K_WORD_PATTERN, 1000);
 
         let samples = vec![
             "hello world",

--- a/crates/wordchuck/src/lib.rs
+++ b/crates/wordchuck/src/lib.rs
@@ -11,7 +11,7 @@
 //! ```rust,no_run
 //! use wordchuck::training::trainer::{BinaryPairVocabTrainer, BinaryPairVocabTrainerOptions};
 //! use wordchuck::vocab::io::tiktoken_io::save_word_map_to_tiktoken_path;
-//! use wordchuck::vocab::public::openai::patterns::GPT3_CL100K_WORD_PATTERN;
+//! use wordchuck::vocab::public::openai::patterns::OA_GPT3_CL100K_WORD_PATTERN;
 //! use wordchuck::vocab::UnifiedTokenVocab;
 //! use wordchuck::encoders::UnifiedVocabEncoder;
 //! use wordchuck::decoders::DictionaryDecoder;
@@ -34,7 +34,7 @@
 //!     type C = u64;
 //!
 //!     let options = BinaryPairVocabTrainerOptions::new(
-//!         GPT3_CL100K_WORD_PATTERN,
+//!         OA_GPT3_CL100K_WORD_PATTERN,
 //!         vocab_size,
 //!     );
 //!

--- a/crates/wordchuck/src/rayon/rayon_decoder.rs
+++ b/crates/wordchuck/src/rayon/rayon_decoder.rs
@@ -72,7 +72,7 @@ mod tests {
     use crate::encoders::token_encoder::TokenEncoder;
     use crate::training::trainer::BinaryPairVocabTrainerOptions;
     use crate::types::{check_is_send, check_is_sync};
-    use crate::vocab::public::openai::patterns::GPT3_CL100K_WORD_PATTERN;
+    use crate::vocab::public::openai::patterns::OA_GPT3_CL100K_WORD_PATTERN;
     use crate::vocab::unified_vocab::UnifiedTokenVocab;
     use alloc::sync::Arc;
     use compact_str::CompactString;
@@ -84,7 +84,7 @@ mod tests {
         type C = u32;
         type K = CompactString;
 
-        let options = BinaryPairVocabTrainerOptions::new(GPT3_CL100K_WORD_PATTERN, 1000);
+        let options = BinaryPairVocabTrainerOptions::new(OA_GPT3_CL100K_WORD_PATTERN, 1000);
 
         let samples = vec![
             "hello world",

--- a/crates/wordchuck/src/rayon/rayon_encoder.rs
+++ b/crates/wordchuck/src/rayon/rayon_encoder.rs
@@ -85,7 +85,7 @@ mod tests {
     use crate::rayon::rayon_encoder::ParallelRayonEncoder;
     use crate::training::BinaryPairVocabTrainerOptions;
     use crate::types::{check_is_send, check_is_sync};
-    use crate::vocab::public::openai::patterns::GPT3_CL100K_WORD_PATTERN;
+    use crate::vocab::public::openai::patterns::OA_GPT3_CL100K_WORD_PATTERN;
     use crate::vocab::{TokenVocabIndex, UnifiedTokenVocab};
     use compact_str::CompactString;
 
@@ -95,7 +95,7 @@ mod tests {
         type C = u32;
         type K = CompactString;
 
-        let options = BinaryPairVocabTrainerOptions::new(GPT3_CL100K_WORD_PATTERN, 1000);
+        let options = BinaryPairVocabTrainerOptions::new(OA_GPT3_CL100K_WORD_PATTERN, 1000);
 
         let samples = vec![
             "hello world",

--- a/crates/wordchuck/src/training/trainer.rs
+++ b/crates/wordchuck/src/training/trainer.rs
@@ -332,7 +332,7 @@ mod tests {
     use crate::training::trainer::{BinaryPairVocabTrainerOptions, MergeJob};
     use crate::types::{check_is_send, check_is_sync};
     use crate::vocab::TokenVocabIndex;
-    use crate::vocab::public::openai::patterns::GPT3_CL100K_WORD_PATTERN;
+    use crate::vocab::public::openai::patterns::OA_GPT3_CL100K_WORD_PATTERN;
     use crate::vocab::unified_vocab::UnifiedTokenVocab;
     use alloc::sync::Arc;
     use compact_str::CompactString;
@@ -340,10 +340,10 @@ mod tests {
 
     #[test]
     fn test_tokenizer_options() {
-        let options = BinaryPairVocabTrainerOptions::new(GPT3_CL100K_WORD_PATTERN, 1000);
+        let options = BinaryPairVocabTrainerOptions::new(OA_GPT3_CL100K_WORD_PATTERN, 1000);
 
         assert_eq!(options.vocab_size, 1000);
-        assert_eq!(options.pattern, GPT3_CL100K_WORD_PATTERN.into());
+        assert_eq!(options.pattern, OA_GPT3_CL100K_WORD_PATTERN.into());
 
         let options = options.with_vocab_size(2000).with_pattern(r"\S+");
 
@@ -363,7 +363,7 @@ mod tests {
         type C = u32;
         type K = CompactString;
 
-        let options = BinaryPairVocabTrainerOptions::new(GPT3_CL100K_WORD_PATTERN, 1000);
+        let options = BinaryPairVocabTrainerOptions::new(OA_GPT3_CL100K_WORD_PATTERN, 1000);
 
         let samples = vec![
             "hello world",

--- a/crates/wordchuck/src/vocab/public/openai/mod.rs
+++ b/crates/wordchuck/src/vocab/public/openai/mod.rs
@@ -1,4 +1,5 @@
 //! Public `OpenAI` Patterns, Constants, and Models.
 
 pub mod patterns;
+pub mod resources;
 pub mod specials;

--- a/crates/wordchuck/src/vocab/public/openai/patterns.rs
+++ b/crates/wordchuck/src/vocab/public/openai/patterns.rs
@@ -5,8 +5,8 @@ use crate::regex::re_wrapper::ConstRegexWrapperPattern;
 
 /// The GPT-2 r50k word pattern.
 ///
-/// Faster than [`GPT2_SLOW_WORD_PATTERN`], optimized for performance.
-pub const GPT2_R50K_WORD_PATTERN: ConstRegexWrapperPattern =
+/// Faster than [`OA_GPT2_R50K_WORD_PATTERN_SLOW`], optimized for performance.
+pub const OA_GPT2_R50K_WORD_PATTERN: ConstRegexWrapperPattern =
     ConstRegexWrapperPattern::Fancy(join_patterns!(
         r"'(?:[sdmt]|ll|ve|re)",
         r" ?\p{L}++",
@@ -18,7 +18,7 @@ pub const GPT2_R50K_WORD_PATTERN: ConstRegexWrapperPattern =
     ));
 
 /// The original GPT-2 word pattern.
-pub const GPT2_SLOW_WORD_PATTERN: ConstRegexWrapperPattern =
+pub const OA_GPT2_R50K_WORD_PATTERN_SLOW: ConstRegexWrapperPattern =
     ConstRegexWrapperPattern::Fancy(join_patterns!(
         r"'s",
         r"'t",
@@ -35,7 +35,7 @@ pub const GPT2_SLOW_WORD_PATTERN: ConstRegexWrapperPattern =
     ));
 
 /// The GPT-3 cl100K word pattern.
-pub const GPT3_CL100K_WORD_PATTERN: ConstRegexWrapperPattern =
+pub const OA_GPT3_CL100K_WORD_PATTERN: ConstRegexWrapperPattern =
     ConstRegexWrapperPattern::Fancy(join_patterns!(
         r"'(?i:[sdmt]|ll|ve|re)",
         r"[^\r\n\p{L}\p{N}]?+\p{L}++",
@@ -48,7 +48,7 @@ pub const GPT3_CL100K_WORD_PATTERN: ConstRegexWrapperPattern =
     ));
 
 /// The GPT-5 o220k word pattern.
-pub const GPT5_O220K_WORD_PATTERN: ConstRegexWrapperPattern = ConstRegexWrapperPattern::Fancy(
+pub const OA_GPT5_O220K_WORD_PATTERN: ConstRegexWrapperPattern = ConstRegexWrapperPattern::Fancy(
     join_patterns!(
         r"[^\r\n\p{L}\p{N}]?[\p{Lu}\p{Lt}\p{Lm}\p{Lo}\p{M}]*[\p{Ll}\p{Lm}\p{Lo}\p{M}]+(?i:'s|'t|'re|'ve|'m|'ll|'d)?",
         r"\p{N}{1,3}",
@@ -65,12 +65,12 @@ mod tests {
 
     #[test]
     fn test_patterns_compile() {
-        assert!(GPT2_R50K_WORD_PATTERN.compile().is_ok());
-        assert!(GPT2_SLOW_WORD_PATTERN.compile().is_ok());
+        assert!(OA_GPT2_R50K_WORD_PATTERN.compile().is_ok());
+        assert!(OA_GPT2_R50K_WORD_PATTERN_SLOW.compile().is_ok());
 
-        assert!(GPT3_CL100K_WORD_PATTERN.compile().is_ok());
+        assert!(OA_GPT3_CL100K_WORD_PATTERN.compile().is_ok());
 
-        assert!(GPT3_CL100K_WORD_PATTERN.compile().is_ok());
-        assert!(GPT5_O220K_WORD_PATTERN.compile().is_ok());
+        assert!(OA_GPT3_CL100K_WORD_PATTERN.compile().is_ok());
+        assert!(OA_GPT5_O220K_WORD_PATTERN.compile().is_ok());
     }
 }

--- a/crates/wordchuck/src/vocab/public/openai/resources.rs
+++ b/crates/wordchuck/src/vocab/public/openai/resources.rs
@@ -1,0 +1,39 @@
+//! # Public `OpenAI` Resources
+
+use crate::vocab::tooling::resource_tools::ConstUrlResource;
+
+/// The GPT-2 Data Gym "vocab.bpe" vocabulary resource.
+pub const OA_GPT2_DATAGYM_VOCAB_BPE: ConstUrlResource = ConstUrlResource {
+    url: "https://openaipublic.blob.core.windows.net/gpt-2/encodings/main/vocab.bpe",
+    hash: Some("1ce1664773c50f3e0cc8842619a93edc4624525b728b188a9e0be33b7726adc5"),
+};
+
+/// The GPT-2 Data Gym "encoder.json" vocabulary resource.
+pub const OA_GPT2_DATAGYM_ENCODER_JSON: ConstUrlResource = ConstUrlResource {
+    url: "https://openaipublic.blob.core.windows.net/gpt-2/encodings/main/encoder.json",
+    hash: Some("196139668be63f3b5d6574427317ae82f612a97c5d1cdaf36ed2256dbf636783"),
+};
+
+/// The "`r50k_base.tiktoken`" vocabulary resource.
+pub const OA_GPT2_R50K_BASE_TIKTOKEN: ConstUrlResource = ConstUrlResource {
+    url: "https://openaipublic.blob.core.windows.net/encodings/r50k_base.tiktoken",
+    hash: Some("306cd27f03c1a714eca7108e03d66b7dc042abe8c258b44c199a7ed9838dd930"),
+};
+
+/// The "`p50k_base.tiktoken`" vocabulary resource.
+pub const OA_GPT2_P50K_BASE_TIKTOKEN: ConstUrlResource = ConstUrlResource {
+    url: "https://openaipublic.blob.core.windows.net/encodings/p50k_base.tiktoken",
+    hash: Some("94b5ca7dff4d00767bc256fdd1b27e5b17361d7b8a5f968547f9f23eb70d2069"),
+};
+
+/// The "`cl100k_base.tiktoken`" vocabulary resource.
+pub const OA_GPT3_CL100K_BASE_TIKTOKEN: ConstUrlResource = ConstUrlResource {
+    url: "https://openaipublic.blob.core.windows.net/encodings/cl100k_base.tiktoken",
+    hash: Some("223921b76ee99bde995b7ff738513eef100fb51d18c93597a113bcffe865b2a7"),
+};
+
+/// The "`o200k_base.tiktoken`" vocabulary resource.
+pub const OA_GPT5_O200K_BASE_TIKTOKEN: ConstUrlResource = ConstUrlResource {
+    url: "https://openaipublic.blob.core.windows.net/encodings/o200k_base.tiktoken",
+    hash: Some("446a9538cb6c348e3516120d7c08b09f57c36495e2acfffe59a5bf8b0cfb1a2d"),
+};

--- a/crates/wordchuck/src/vocab/tooling/mod.rs
+++ b/crates/wordchuck/src/vocab/tooling/mod.rs
@@ -1,4 +1,5 @@
 //! # Vocab Support Tooling
 
 pub mod pattern_tools;
+pub mod resource_tools;
 pub mod specials_tools;

--- a/crates/wordchuck/src/vocab/tooling/resource_tools.rs
+++ b/crates/wordchuck/src/vocab/tooling/resource_tools.rs
@@ -1,0 +1,25 @@
+//! # Remote Resource Tools
+/// A resource with a constant URL and optional hash.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct ConstUrlResource {
+    /// The URL associated with this resource.
+    pub url: &'static str,
+
+    /// The hash associated with this resource, if available.
+    pub hash: Option<&'static str>,
+}
+
+impl ConstUrlResource {
+    /// Create a new [`ConstUrlResource`].
+    pub const fn new(
+        url: &'static str,
+        hash: Option<&'static str>,
+    ) -> Self {
+        Self { url, hash }
+    }
+
+    /// Create a new [`ConstUrlResource`] with no hash.
+    pub const fn no_hash(url: &'static str) -> Self {
+        Self::new(url, None)
+    }
+}


### PR DESCRIPTION
This pull request updates OpenAI-related patterns and expands tooling for resource handling. Key changes include:

- Renaming `GPT3_CL100K_WORD_PATTERN` to `OA_GPT3_CL100K_WORD_PATTERN` for clarity and uniformity.
- Adding `ConstUrlResource` struct to manage URLs with optional hash validation.
- Introducing constants for OpenAI GPT vocabulary resources (e.g., GPT-2, GPT-3, GPT-5).
- Updating references, tests, and documentation to reflect the renamed pattern.
- Extending the `resource_tools` module to support external resource management. 
