### PR TITLE
alt_list => exact_match_union.

### DIFF
--- a/crates/wordchuck/src/encoders/text_segmentor.rs
+++ b/crates/wordchuck/src/encoders/text_segmentor.rs
@@ -1,7 +1,7 @@
 //! # Text Segmentor
 
 use crate::regex::RegexSupplierHandle;
-use crate::regex::alt_list::fixed_alternative_list_regex_wrapper;
+use crate::regex::exact_match_union::exact_match_union_regex_wrapper;
 use crate::regex::{RegexWrapperPattern, maybe_parallel_regex_supplier};
 use crate::vocab::public::size_hints::EXPECTED_BYTES_PER_TOKEN;
 use core::ops::Range;
@@ -36,7 +36,7 @@ impl TextSegmentor {
 
         let special_re_supplier: Option<RegexSupplierHandle> = match specials.as_ref() {
             Some(specials) if !specials.is_empty() => Some(maybe_parallel_regex_supplier(
-                fixed_alternative_list_regex_wrapper(specials),
+                exact_match_union_regex_wrapper(specials),
             )),
             _ => None,
         };

--- a/crates/wordchuck/src/regex/exact_match_union.rs
+++ b/crates/wordchuck/src/regex/exact_match_union.rs
@@ -1,11 +1,11 @@
-//! Alternative List Utilities
+//! Exact Match Union Patterns
 
 use crate::regex::re_wrapper::{RegexWrapper, RegexWrapperPattern};
 
-/// Create a list of fixed-match alternatives into a regex pattern.
+/// Create a union pattern of exact matches.
 ///
 /// This will always be a [`RegexWrapperPattern::Basic`] variant.
-pub fn fixed_alternative_list_regex_pattern<S: AsRef<str>>(alts: &[S]) -> RegexWrapperPattern {
+pub fn exact_match_union_regex_pattern<S: AsRef<str>>(alts: &[S]) -> RegexWrapperPattern {
     let parts = alts
         .iter()
         .map(|s| fancy_regex::escape(s.as_ref()))
@@ -13,11 +13,11 @@ pub fn fixed_alternative_list_regex_pattern<S: AsRef<str>>(alts: &[S]) -> RegexW
     RegexWrapperPattern::Basic(format!("({})", parts.join("|")))
 }
 
-/// Create a list of fixed-match alternatives into a compiled regex.
-pub fn fixed_alternative_list_regex_wrapper<S: AsRef<str>>(alts: &[S]) -> RegexWrapper {
-    fixed_alternative_list_regex_pattern(alts)
-        .compile()
-        .unwrap()
+/// Create a union pattern of exact matches, compiled into a [`RegexWrapper`].
+///
+/// See: [`exact_match_union_regex_pattern`]
+pub fn exact_match_union_regex_wrapper<S: AsRef<str>>(alts: &[S]) -> RegexWrapper {
+    exact_match_union_regex_pattern(alts).compile().unwrap()
 }
 
 #[cfg(test)]
@@ -28,10 +28,10 @@ mod tests {
     fn test_fixed_alternative_list() {
         let alternatives = ["apple", "[x]", "boat"];
 
-        let pattern = fixed_alternative_list_regex_pattern(&alternatives);
+        let pattern = exact_match_union_regex_pattern(&alternatives);
         assert_eq!(pattern.as_str(), r"(apple|\[x\]|boat)");
 
-        let re = fixed_alternative_list_regex_wrapper(&alternatives);
+        let re = exact_match_union_regex_wrapper(&alternatives);
 
         let text = "apple 123 [x] xyz boat";
         assert_eq!(re.find_iter(text).count(), 3);

--- a/crates/wordchuck/src/regex/mod.rs
+++ b/crates/wordchuck/src/regex/mod.rs
@@ -39,7 +39,7 @@
 //! [`maybe_parallel_regex_supplier`]; which in some build environments will provide
 //! a thread local clone regex supplier, and in some, a simple clone implementation.
 
-pub mod alt_list;
+pub mod exact_match_union;
 #[cfg(feature = "std")]
 pub mod re_pool;
 


### PR DESCRIPTION
Refactor regex utilities to replace `fixed_alternative_list` with `exact_match_union` for improved clarity and consistency