### PR TITLE
Rename wordchuck interfaces for clarity and consistency

### DIFF
--- a/crates/wordchuck/src/training/mod.rs
+++ b/crates/wordchuck/src/training/mod.rs
@@ -1,8 +1,8 @@
 //! # Vocabulary Training
 
-pub mod pair_index;
+pub mod pair_span_index;
+pub mod text_span_counter;
+pub mod token_span_buffer;
 pub mod trainer;
-pub mod word;
-pub mod word_count;
 
 pub use trainer::{BinaryPairVocabTrainer, BinaryPairVocabTrainerOptions};


### PR DESCRIPTION
- Renamed `Word` to `TokenSpanBuf` to better align with functionality.
- Updated module names:
  - `word` → `token_span_buffer`
  - `pair_index` → `pair_span_index`
  - `word_count` → `text_span_counter`
- Refactored related tests, comments, and imports to reflect the renaming.
- Adjusted pair management processes:
  - `PairIndex` → `PairSpanIndex` for improved semantic coherence.
