### PR TITLE
Introduce `SegmentationConfig` and restructure text segmentation logic

### DIFF
--- a/crates/wordchuck/src/decoders/byte_decoder.rs
+++ b/crates/wordchuck/src/decoders/byte_decoder.rs
@@ -7,20 +7,22 @@ use crate::types::TokenType;
 use crate::vocab::TokenVocabIndex;
 use crate::vocab::byte_table::ByteTable;
 use crate::vocab::vocab_index::byte_tokens_iter;
+use std::sync::Arc;
 
 /// A decoders that only decodes byte tokens.
 #[derive(Clone, Default)]
 pub struct ByteDecoder<T: TokenType> {
-    byte_table: ByteTable<T>,
-    _marker: std::marker::PhantomData<T>,
+    byte_table: Arc<ByteTable<T>>,
 }
 
 impl<T: TokenType> ByteDecoder<T> {
     /// Create a new byte decoder.
-    pub fn new(byte_table: ByteTable<T>) -> Self {
+    pub fn new<B>(byte_table: B) -> Self
+    where
+        B: Into<Arc<ByteTable<T>>>,
+    {
         Self {
-            byte_table,
-            _marker: Default::default(),
+            byte_table: byte_table.into(),
         }
     }
 

--- a/crates/wordchuck/src/decoders/dictionary_decoder.rs
+++ b/crates/wordchuck/src/decoders/dictionary_decoder.rs
@@ -16,8 +16,7 @@ pub struct DictionaryDecoder<T: TokenType> {
 
 impl<T: TokenType> DictionaryDecoder<T> {
     /// Creates a new Decoder.
-    pub fn new(mut token_to_word: TokenToWordMap<T>) -> Self {
-        token_to_word.shrink_to_fit();
+    pub fn new(token_to_word: TokenToWordMap<T>) -> Self {
         Self { token_to_word }
     }
 }
@@ -37,8 +36,6 @@ impl<T: TokenType> TokenDecoder<T> for DictionaryDecoder<T> {
         while let Some(t) = ctx.stack.pop() {
             if let Some(w) = self.token_to_word.get(&t) {
                 ctx.buf.extend_from_slice(w.as_slice());
-            } else if let Some(b) = t.to_u8() {
-                ctx.buf.push(b);
             } else {
                 ctx.stack.push(t);
                 break;

--- a/crates/wordchuck/src/encoders/mod.rs
+++ b/crates/wordchuck/src/encoders/mod.rs
@@ -1,6 +1,5 @@
 //! # Token Encoders
 
-pub mod text_segmentor;
 pub mod token_encoder;
 pub mod unified_encoder;
 

--- a/crates/wordchuck/src/encoders/token_encoder.rs
+++ b/crates/wordchuck/src/encoders/token_encoder.rs
@@ -1,6 +1,6 @@
 //! # Token Encoder Trait
 
-use crate::encoders::text_segmentor::WordRef;
+use crate::segmentation::text_segmentor::WordRef;
 use crate::types::TokenType;
 use crate::vocab::TokenVocabIndex;
 use crate::vocab::public::size_hints::EXPECTED_BYTES_PER_TOKEN;

--- a/crates/wordchuck/src/lib.rs
+++ b/crates/wordchuck/src/lib.rs
@@ -72,13 +72,14 @@
 
 extern crate alloc;
 
+#[cfg(feature = "rayon")]
+pub mod rayon;
+
 pub mod decoders;
 pub mod encoders;
 pub mod regex;
+pub mod segmentation;
 pub mod training;
 pub mod types;
 pub mod util;
 pub mod vocab;
-
-#[cfg(feature = "rayon")]
-pub mod rayon;

--- a/crates/wordchuck/src/rayon/rayon_encoder.rs
+++ b/crates/wordchuck/src/rayon/rayon_encoder.rs
@@ -1,7 +1,7 @@
 //! # Parallel Encoder
 
 use crate::encoders::TokenEncoder;
-use crate::encoders::text_segmentor::WordRef;
+use crate::segmentation::text_segmentor::WordRef;
 use crate::types::TokenType;
 use crate::vocab::TokenVocabIndex;
 use crate::vocab::special_vocab::SpecialWordsTokenVocab;

--- a/crates/wordchuck/src/segmentation/mod.rs
+++ b/crates/wordchuck/src/segmentation/mod.rs
@@ -1,0 +1,7 @@
+//! # Text Segmentation
+
+pub mod segmentation_config;
+pub mod text_segmentor;
+
+pub use segmentation_config::SegmentationConfig;
+pub use text_segmentor::{TextSegmentor, WordRef};

--- a/crates/wordchuck/src/segmentation/segmentation_config.rs
+++ b/crates/wordchuck/src/segmentation/segmentation_config.rs
@@ -1,0 +1,60 @@
+//! # Text Segmentation Configuration
+use crate::regex::RegexWrapperPattern;
+use crate::types::TokenType;
+use crate::vocab::special_vocab::SpecialWordsTokenVocab;
+
+/// Word Split + Special Words Segmentor Configuration
+#[derive(Debug, Clone)]
+pub struct SegmentationConfig<T: TokenType> {
+    /// Regex pattern for word splitting.
+    pub word_pattern: RegexWrapperPattern,
+
+    /// Special tokens vocabulary.
+    pub specials: SpecialWordsTokenVocab<T>,
+}
+
+impl<T: TokenType> SegmentationConfig<T> {
+    /// Create a new text segmentor configuration with the given word pattern.
+    ///
+    /// Will contain an empty list of specials.
+    pub fn from_pattern(word_pattern: RegexWrapperPattern) -> Self {
+        Self {
+            word_pattern,
+            specials: SpecialWordsTokenVocab::default(),
+        }
+    }
+
+    /// Set the word pattern for the text segmentor configuration.
+    pub fn with_word_pattern(
+        self,
+        word_pattern: RegexWrapperPattern,
+    ) -> Self {
+        Self {
+            word_pattern,
+            ..self
+        }
+    }
+
+    /// Replace special tokens vocabulary.
+    pub fn with_specials(
+        self,
+        specials: Option<SpecialWordsTokenVocab<T>>,
+    ) -> Self {
+        let specials = specials.unwrap_or_default();
+        Self { specials, ..self }
+    }
+
+    /// Get the word pattern for the text segmentor configuration.
+    pub fn pattern(&self) -> String {
+        self.word_pattern.as_str().to_string()
+    }
+
+    /// Get the special tokens vocabulary for the text segmentor configuration.
+    pub fn special_vocab(&self) -> Option<&SpecialWordsTokenVocab<T>> {
+        if self.specials.is_empty() {
+            None
+        } else {
+            Some(&self.specials)
+        }
+    }
+}


### PR DESCRIPTION
- Added `SegmentationConfig` to encapsulate word segmentation patterns and special vocab logic.
- Refactored `UnifiedTokenVocab` to use `SegmentationConfig` for improved modularity and clarity.
- Moved `TextSegmentor` under a new `segmentation` module, consolidated related imports.
- Updated `DictionaryDecoder`, `UnifiedEncoder`, and related components to utilize the new segmentation structure.
- Improved flexibility and encapsulation across segmentation-related APIs.