### PR TITLE
Refactor and rename `ByteSpanTokenMap` to `SpanTokenMap`

### DIFF
--- a/crates/wordchuck/examples/token-cli/src/main.rs
+++ b/crates/wordchuck/examples/token-cli/src/main.rs
@@ -8,12 +8,12 @@ use wordchuck::decoders::{DictionaryDecoder, TokenDecoder};
 use wordchuck::encoders::{TokenEncoder, UnifiedVocabEncoder};
 use wordchuck::rayon::{ParallelRayonDecoder, ParallelRayonEncoder};
 use wordchuck::regex::RegexWrapperPattern;
-use wordchuck::types::ByteSpanTokenMap;
+use wordchuck::types::SpanTokenMap;
 use wordchuck::vocab::io::tiktoken_io::load_span_map_from_tiktoken_path;
 use wordchuck::vocab::public::openai::patterns::OA_GPT2_R50K_WORD_PATTERN;
 use wordchuck::vocab::public::openai::resources::OA_GPT2_R50K_BASE_TIKTOKEN;
 use wordchuck::vocab::public::openai::specials::oa_gpt2_r50k_specials;
-use wordchuck::vocab::{ByteSpanTokenMapVocab, UnifiedTokenVocab};
+use wordchuck::vocab::{SpanTokenVocab, UnifiedTokenVocab};
 
 /// Example encoders trainer.
 #[derive(Parser, Debug)]
@@ -73,14 +73,14 @@ fn run_load(
     let specials = oa_gpt2_r50k_specials();
     type T = u16;
     let span_map = load_span_map_from_tiktoken_path(tokenizer_file)?;
-    let word_vocab = ByteSpanTokenMapVocab::from_span_map(span_map);
+    let word_vocab = SpanTokenVocab::from_span_map(span_map);
     let pair_vocab = word_vocab.to_pair_vocab();
 
     let specials_vocab = Some(
         specials
             .iter()
             .map(|(s, t)| (s.as_bytes().to_vec(), *t as T))
-            .collect::<ByteSpanTokenMap<T>>()
+            .collect::<SpanTokenMap<T>>()
             .into(),
     );
 

--- a/crates/wordchuck/examples/tokenizer_trainer/src/main.rs
+++ b/crates/wordchuck/examples/tokenizer_trainer/src/main.rs
@@ -9,10 +9,11 @@ use wordchuck::decoders::{DictionaryDecoder, TokenDecoder};
 use wordchuck::encoders::{TokenEncoder, UnifiedVocabEncoder};
 use wordchuck::rayon::{ParallelRayonDecoder, ParallelRayonEncoder};
 use wordchuck::training::BinaryPairVocabTrainerOptions;
+use wordchuck::types::SpanTokenMap;
 use wordchuck::vocab::byte_table::ByteTokenTable;
 use wordchuck::vocab::io::tiktoken_io::save_span_map_to_tiktoken_path;
 use wordchuck::vocab::public::openai::patterns::OA_GPT3_CL100K_WORD_PATTERN;
-use wordchuck::vocab::{TokenVocabIndex, UnifiedTokenVocab};
+use wordchuck::vocab::{SpanTokenVocab, TokenVocabIndex, UnifiedTokenVocab};
 
 /// Example encoders trainer.
 #[derive(Parser, Debug)]
@@ -117,14 +118,27 @@ fn main() -> anyhow::Result<()> {
     let byte_table: Arc<ByteTokenTable<T>> = Arc::new(Default::default());
 
     println!("- train");
-    let vocab: Arc<UnifiedTokenVocab<T>> = trainer
-        .train(byte_table.clone())
-        .expect("training failed")
-        .into();
+    let vocab: UnifiedTokenVocab<T> = trainer.train(byte_table.clone()).expect("training failed");
 
     let training_duration = std::time::Instant::now().duration_since(t0);
     println!("- training_duration: {:.2?}", training_duration);
     println!("- vocab_size: {:?}", vocab.max_token());
+
+    // Rebuild the vocab:
+    // 1. build a span vocab from the pair table.
+    //    - the pair table has only one parent per target token.
+    // 2. build a pair vocab from the span vocab.
+    //    - this table has all pairs which will build a given token.
+    // 3. build a unified vocab from the pair vocab and span vocab.
+
+    let span_map: SpanTokenMap<T> = vocab.pair_vocab.to_span_pairs().collect();
+    let span_vocab = SpanTokenVocab::<T>::init(byte_table, span_map).unwrap();
+    let pair_vocab = span_vocab.to_pair_vocab();
+
+    let vocab: Arc<UnifiedTokenVocab<T>> = vocab
+        .with_word_vocab(span_vocab)
+        .with_pair_vocab(pair_vocab)
+        .into();
 
     if let Some(path) = args.tiktoken_save_path {
         save_span_map_to_tiktoken_path(vocab.word_vocab.span_map(), &path)?;

--- a/crates/wordchuck/src/encoders/unified_encoder.rs
+++ b/crates/wordchuck/src/encoders/unified_encoder.rs
@@ -1,6 +1,5 @@
 //! # Encoder for [`UnifiedTokenVocab`].
 
-use crate::decoders::dictionary_decoder::DictionaryDecoder;
 use crate::encoders::token_encoder::TokenEncoder;
 use crate::segmentation::text_segmentor::{TextSegmentor, WordRef};
 use crate::types::TokenType;
@@ -32,11 +31,6 @@ impl<T: TokenType> UnifiedVocabEncoder<T> {
             segmentor,
             byte_table,
         }
-    }
-
-    /// Build a [`DictionaryDecoder`] from this [`UnifiedVocabEncoder`].
-    pub fn to_decoder(&self) -> DictionaryDecoder<T> {
-        self.data.to_decoder()
     }
 }
 
@@ -124,6 +118,7 @@ impl<T: TokenType> TokenEncoder<T> for UnifiedVocabEncoder<T> {
 
 #[cfg(test)]
 mod tests {
+    use crate::decoders::DictionaryDecoder;
     use crate::decoders::token_decoder::TokenDecoder;
     use crate::encoders::token_encoder::TokenEncoder;
     use crate::encoders::unified_encoder::UnifiedVocabEncoder;
@@ -160,13 +155,13 @@ mod tests {
 
         let special_sample = "hello <|HI|> world";
 
-        let encoder = UnifiedVocabEncoder::<T>::new(Arc::new(vocab));
+        let encoder = UnifiedVocabEncoder::<T>::new(vocab.clone().into());
         check_is_send(&encoder);
         check_is_sync(&encoder);
 
         assert_eq!(encoder.max_token(), 292);
 
-        let decoder = encoder.to_decoder();
+        let decoder = DictionaryDecoder::new(vocab.compiled_dictionary());
         check_is_send(&decoder);
         check_is_sync(&decoder);
 

--- a/crates/wordchuck/src/rayon/rayon_encoder.rs
+++ b/crates/wordchuck/src/rayon/rayon_encoder.rs
@@ -80,7 +80,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use crate::decoders::TokenDecoder;
+    use crate::decoders::{DictionaryDecoder, TokenDecoder};
     use crate::encoders::{TokenEncoder, UnifiedVocabEncoder};
     use crate::rayon::rayon_encoder::ParallelRayonEncoder;
     use crate::training::BinaryPairVocabTrainerOptions;
@@ -119,7 +119,7 @@ mod tests {
 
         let special_sample = "hello <|HI|> world";
 
-        let encoder = UnifiedVocabEncoder::<T>::new(vocab.into());
+        let encoder = UnifiedVocabEncoder::<T>::new(vocab.clone().into());
         check_is_send(&encoder);
         check_is_sync(&encoder);
 
@@ -129,7 +129,7 @@ mod tests {
 
         assert_eq!(encoder.max_token(), 292);
 
-        let decoder = encoder.inner.to_decoder();
+        let decoder = DictionaryDecoder::new(vocab.compiled_dictionary());
         check_is_send(&decoder);
         check_is_sync(&decoder);
 

--- a/crates/wordchuck/src/training/bpe_trainer.rs
+++ b/crates/wordchuck/src/training/bpe_trainer.rs
@@ -338,7 +338,8 @@ where
 
         pairs.shrink_to_fit();
 
-        let pair_vocab: PairTokenMapVocab<T> = PairTokenMapVocab::new(byte_table, pairs);
+        let pair_vocab: PairTokenMapVocab<T> =
+            PairTokenMapVocab::<T>::init(byte_table, pairs).unwrap();
 
         let vocab = UnifiedTokenVocab::<T>::new(self.options.pattern).with_pair_vocab(pair_vocab);
 
@@ -350,6 +351,7 @@ where
 
 #[cfg(test)]
 mod tests {
+    use crate::decoders::DictionaryDecoder;
     use crate::decoders::token_decoder::TokenDecoder;
     use crate::encoders::token_encoder::TokenEncoder;
     use crate::encoders::unified_encoder::UnifiedVocabEncoder;
@@ -401,15 +403,15 @@ mod tests {
 
         let byte_table: Arc<ByteTokenTable<T>> = Arc::new(Default::default());
 
-        let vocab: Arc<UnifiedTokenVocab<T>> = trainer.train(byte_table.clone()).unwrap().into();
+        let vocab: UnifiedTokenVocab<T> = trainer.train(byte_table.clone()).unwrap();
 
-        let encoder = UnifiedVocabEncoder::<T>::new(vocab.clone());
+        let encoder = UnifiedVocabEncoder::<T>::new(vocab.clone().into());
         check_is_send(&encoder);
         check_is_sync(&encoder);
 
         assert_eq!(encoder.max_token(), 292);
 
-        let decoder = encoder.to_decoder();
+        let decoder = DictionaryDecoder::new(vocab.compiled_dictionary());
         check_is_send(&decoder);
         check_is_sync(&decoder);
 

--- a/crates/wordchuck/src/types.rs
+++ b/crates/wordchuck/src/types.rs
@@ -98,7 +98,7 @@ pub type PairTokenMap<T> = ahash::AHashMap<Pair<T>, T>;
 pub type TokenToPairMap<T> = ahash::AHashMap<T, Pair<T>>;
 
 /// Byte vector to T map.
-pub type ByteSpanTokenMap<T> = ahash::AHashMap<Vec<u8>, T>;
+pub type SpanTokenMap<T> = ahash::AHashMap<Vec<u8>, T>;
 
 /// T to byte vector map.
 pub type TokenToWordMap<T> = ahash::AHashMap<T, Vec<u8>>;

--- a/crates/wordchuck/src/vocab/io/tiktoken_io.rs
+++ b/crates/wordchuck/src/vocab/io/tiktoken_io.rs
@@ -1,6 +1,6 @@
 //! # Tiktoken Vocabulary IO
 
-use crate::types::{ByteSpanTokenMap, TokenType};
+use crate::types::{SpanTokenMap, TokenType};
 use ahash::AHashMap;
 use anyhow::Context;
 use base64::Engine;
@@ -8,11 +8,11 @@ use base64::prelude::BASE64_STANDARD;
 use std::io::{BufRead, BufReader, BufWriter, Write};
 use std::path::Path;
 
-/// Load a [`ByteSpanTokenMap`] from a tiktoken vocab file.
+/// Load a [`SpanTokenMap`] from a tiktoken vocab file.
 ///
 /// # Arguments
 /// * `path` - the path to the vocabulary file.
-pub fn load_span_map_from_tiktoken_path<T, P>(path: P) -> anyhow::Result<ByteSpanTokenMap<T>>
+pub fn load_span_map_from_tiktoken_path<T, P>(path: P) -> anyhow::Result<SpanTokenMap<T>>
 where
     T: TokenType,
     P: AsRef<Path>,
@@ -23,12 +23,12 @@ where
     load_span_map_from_tiktoken_reader(reader)
 }
 
-/// Update a [`ByteSpanTokenMap`] from a tiktoken vocab [`BufRead`] stream.
+/// Update a [`SpanTokenMap`] from a tiktoken vocab [`BufRead`] stream.
 ///
 /// # Arguments
 /// * `span_map` - the vocabulary to extend.
 /// * `reader` - the line reader.
-pub fn load_span_map_from_tiktoken_reader<T, R>(reader: R) -> anyhow::Result<ByteSpanTokenMap<T>>
+pub fn load_span_map_from_tiktoken_reader<T, R>(reader: R) -> anyhow::Result<SpanTokenMap<T>>
 where
     T: TokenType,
     R: BufRead,
@@ -55,13 +55,13 @@ where
     Ok(vocab)
 }
 
-/// Save a [`ByteSpanTokenMap`] to a tiktoken vocab file.
+/// Save a [`SpanTokenMap`] to a tiktoken vocab file.
 ///
 /// # Arguments
 /// * `span_map` - the vocabulary to save.
 /// * `path` - the path to save the vocabulary to.
 pub fn save_span_map_to_tiktoken_path<T: TokenType, P: AsRef<Path>>(
-    span_map: &ByteSpanTokenMap<T>,
+    span_map: &SpanTokenMap<T>,
     path: P,
 ) -> anyhow::Result<()> {
     let file = std::fs::File::create(path)?;
@@ -70,9 +70,9 @@ pub fn save_span_map_to_tiktoken_path<T: TokenType, P: AsRef<Path>>(
     save_span_map_to_tiktoken_writer(span_map, &mut writer)
 }
 
-/// Save a [`ByteSpanTokenMap`] to a [`Write`] writer.
+/// Save a [`SpanTokenMap`] to a [`Write`] writer.
 pub fn save_span_map_to_tiktoken_writer<T, W>(
-    span_map: &ByteSpanTokenMap<T>,
+    span_map: &SpanTokenMap<T>,
     writer: &mut W,
 ) -> anyhow::Result<()>
 where

--- a/crates/wordchuck/src/vocab/mod.rs
+++ b/crates/wordchuck/src/vocab/mod.rs
@@ -1,17 +1,17 @@
 //! # Vocabulary
 
-pub mod byte_span_vocab;
 pub mod byte_table;
 pub mod io;
 pub mod pair_vocab;
 pub mod public;
+pub mod span_vocab;
 pub mod special_vocab;
 pub mod tooling;
 pub mod unified_vocab;
 pub mod vocab_index;
 
-pub use byte_span_vocab::ByteSpanTokenMapVocab;
 pub use byte_table::ByteTokenTable;
 pub use pair_vocab::PairTokenMapVocab;
+pub use span_vocab::SpanTokenVocab;
 pub use unified_vocab::UnifiedTokenVocab;
 pub use vocab_index::TokenVocabIndex;

--- a/crates/wordchuck/src/vocab/span_vocab.rs
+++ b/crates/wordchuck/src/vocab/span_vocab.rs
@@ -1,34 +1,34 @@
 //! # Word Map ``{ Vec<u8> -> T }`` Token Vocabulary
 
-use crate::types::{ByteSpanTokenMap, TokenType};
+use crate::types::{SpanTokenMap, TokenType};
 use crate::vocab::{ByteTokenTable, PairTokenMapVocab, TokenVocabIndex};
 use ahash::AHashMap;
 use alloc::sync::Arc;
 
 /// Token vocabulary as a dictionary map of ``{ Vec<u8> -> T }``.
 #[derive(Debug, Clone, PartialEq)]
-pub struct ByteSpanTokenMapVocab<T: TokenType> {
+pub struct SpanTokenVocab<T: TokenType> {
     /// The byte/token mapping table.
     byte_table: Arc<ByteTokenTable<T>>,
 
     /// The regex pattern used for text spl
     /// Map of ``{ Vec<u8> -> T }``.
-    span_map: ByteSpanTokenMap<T>,
+    span_map: SpanTokenMap<T>,
 }
 
-impl<T: TokenType> Default for ByteSpanTokenMapVocab<T> {
+impl<T: TokenType> Default for SpanTokenVocab<T> {
     fn default() -> Self {
-        ByteSpanTokenMapVocab::from_byte_table(Arc::new(ByteTokenTable::default()))
+        SpanTokenVocab::from_byte_table(Arc::new(ByteTokenTable::default()))
     }
 }
 
-impl<T: TokenType> From<ByteSpanTokenMap<T>> for ByteSpanTokenMapVocab<T> {
-    fn from(span_map: ByteSpanTokenMap<T>) -> Self {
+impl<T: TokenType> From<SpanTokenMap<T>> for SpanTokenVocab<T> {
+    fn from(span_map: SpanTokenMap<T>) -> Self {
         Self::from_span_map(span_map)
     }
 }
 
-impl<'a, T: TokenType> IntoIterator for &'a ByteSpanTokenMapVocab<T> {
+impl<'a, T: TokenType> IntoIterator for &'a SpanTokenVocab<T> {
     type Item = (&'a Vec<u8>, &'a T);
 
     type IntoIter = std::collections::hash_map::Iter<'a, Vec<u8>, T>;
@@ -38,7 +38,7 @@ impl<'a, T: TokenType> IntoIterator for &'a ByteSpanTokenMapVocab<T> {
     }
 }
 
-impl<T: TokenType> ByteSpanTokenMapVocab<T> {
+impl<T: TokenType> SpanTokenVocab<T> {
     /// Build vocabulary from just a [`ByteTokenTable`].
     ///
     /// Will have 255 span entries, each 1-byte long.
@@ -48,19 +48,19 @@ impl<T: TokenType> ByteSpanTokenMapVocab<T> {
     {
         let byte_table = byte_table.into();
 
-        let span_map: ByteSpanTokenMap<T> = byte_table.to_span_pairs().collect();
+        let span_map: SpanTokenMap<T> = byte_table.to_span_pairs().collect();
 
-        Self::new(byte_table, span_map)
+        Self::init(byte_table, span_map).unwrap()
     }
 
-    /// Build a vocabulary from just a [`ByteSpanTokenMap`].
+    /// Build a [`Self`] from a [`SpanTokenMap`].
     ///
-    /// The [`ByteTokenTable`] will be inferred from the [`ByteSpanTokenMap`],
+    /// The [`ByteTokenTable`] will be inferred from the [`SpanTokenMap`],
     /// and the default ordinal byte to token mappings.
     ///
     /// # Panics
     /// If the [`ByteTokenTable`] mapping is not 1:1.
-    pub fn from_span_map(span_map: ByteSpanTokenMap<T>) -> Self {
+    pub fn from_span_map(span_map: SpanTokenMap<T>) -> Self {
         let byte_to_token = (0..256)
             .map(|ord| {
                 let byte = ord as u8;
@@ -74,27 +74,25 @@ impl<T: TokenType> ByteSpanTokenMapVocab<T> {
 
         let byte_table = Arc::new(ByteTokenTable::from_byte_to_token(&byte_to_token));
 
-        Self::new(byte_table, span_map)
+        Self::init(byte_table, span_map).unwrap()
     }
 
     /// Build word vocabulary from a [`PairTokenMapVocab<T>`].
     pub fn from_pair_vocab(pair_vocab: &PairTokenMapVocab<T>) -> Self {
         let byte_table: Arc<ByteTokenTable<T>> = pair_vocab.byte_table().clone();
-        let span_map: ByteSpanTokenMap<T> = byte_table.to_span_pairs().collect();
-        Self::new(byte_table, span_map)
+        let span_map: SpanTokenMap<T> = pair_vocab.to_span_pairs().collect();
+
+        Self::init(byte_table, span_map).unwrap()
     }
 
-    /// Build vocabulary.
+    /// Initialize a [`SpanTokenVocab`].
     ///
     /// The span map will be the union of the span map,
     /// and all overrides from the `byte_table`.
-    ///
-    /// # Panics
-    /// If the [`ByteTokenTable`] disagrees with the `span_map`.
-    pub fn new<B>(
+    pub fn init<B>(
         byte_table: B,
-        mut span_map: ByteSpanTokenMap<T>,
-    ) -> Self
+        mut span_map: SpanTokenMap<T>,
+    ) -> anyhow::Result<Self>
     where
         B: Into<Arc<ByteTokenTable<T>>>,
     {
@@ -103,21 +101,22 @@ impl<T: TokenType> ByteSpanTokenMapVocab<T> {
             if let Some(previous) = span_map.insert(span, token)
                 && previous != token
             {
-                panic!(
+                anyhow::bail!(
                     "ByteTable disagrees with span_map: {:?} != {:?}",
-                    previous, token
+                    previous,
+                    token
                 );
             }
         }
 
-        Self {
+        Ok(Self {
             byte_table,
             span_map,
-        }
+        })
     }
 
     /// Get the span => token map.
-    pub fn span_map(&self) -> &ByteSpanTokenMap<T> {
+    pub fn span_map(&self) -> &SpanTokenMap<T> {
         &self.span_map
     }
 
@@ -157,14 +156,14 @@ impl<T: TokenType> ByteSpanTokenMapVocab<T> {
 
         let mut pairs = AHashMap::default();
 
-        let token_to_words: AHashMap<T, &[u8]> = self
+        let token_to_span: AHashMap<T, &[u8]> = self
             .span_map
             .iter()
             .map(|(chunk, &token)| (token, chunk.as_ref()))
             .collect();
 
         for token in self.unordered_tokens_iter() {
-            let word = token_to_words[&token];
+            let word = token_to_span[&token];
 
             let k = word.len();
             for p in 1..k {
@@ -178,11 +177,11 @@ impl<T: TokenType> ByteSpanTokenMapVocab<T> {
             }
         }
 
-        PairTokenMapVocab::new(byte_table, pairs)
+        PairTokenMapVocab::<T>::init(byte_table, pairs).unwrap()
     }
 }
 
-impl<T: TokenType> TokenVocabIndex<T> for ByteSpanTokenMapVocab<T> {
+impl<T: TokenType> TokenVocabIndex<T> for SpanTokenVocab<T> {
     fn unordered_tokens_iter(&self) -> impl Iterator<Item = T> {
         self.span_map.values().copied()
     }
@@ -199,7 +198,7 @@ mod tests {
 
         let byte_table: ByteTokenTable<T> = Default::default();
 
-        let vocab = ByteSpanTokenMapVocab::<T>::default();
+        let vocab = SpanTokenVocab::<T>::default();
 
         assert_eq!(vocab.max_token(), byte_table.max_token());
         assert_eq!(&vocab.sorted_tokens(), &byte_table.sorted_tokens());
@@ -210,7 +209,7 @@ mod tests {
         span_map.insert("banana".as_bytes().to_vec(), 301);
         span_map.insert("pear".as_bytes().to_vec(), 302);
 
-        let vocab = ByteSpanTokenMapVocab::from(span_map);
+        let vocab = SpanTokenVocab::from(span_map);
 
         assert_eq!(vocab.max_token(), 302);
 
@@ -232,7 +231,7 @@ mod tests {
         span_map.insert("apple".as_bytes().to_vec(), 300);
         span_map.insert("a".as_bytes().to_vec(), 301);
 
-        let vocab = ByteSpanTokenMapVocab::<T>::from_span_map(span_map);
+        let vocab = SpanTokenVocab::<T>::from_span_map(span_map);
 
         assert_eq!(vocab.lookup_token(b"apple"), Some(300));
         assert_eq!(vocab.lookup_token(b"a"), Some(301));
@@ -248,7 +247,7 @@ mod tests {
         span_map.insert("ate".as_bytes().to_vec(), 301);
         span_map.insert("cat".as_bytes().to_vec(), 302);
 
-        let vocab = ByteSpanTokenMapVocab::from(span_map);
+        let vocab = SpanTokenVocab::from(span_map);
 
         let pair_vocab = vocab.to_pair_vocab();
         assert_eq!(

--- a/crates/wordchuck/src/vocab/special_vocab.rs
+++ b/crates/wordchuck/src/vocab/special_vocab.rs
@@ -1,6 +1,6 @@
 //! # Special Words Vocabulary
 
-use crate::types::{ByteSpanTokenMap, TokenType};
+use crate::types::{SpanTokenMap, TokenType};
 use crate::vocab::TokenVocabIndex;
 
 /// Token vocabulary as a dictionary map of ``{ Vec<u8> -> T }``.
@@ -10,18 +10,18 @@ use crate::vocab::TokenVocabIndex;
 pub struct SpecialWordsTokenVocab<T: TokenType> {
     /// The regex pattern used for text spl
     /// Map of ``{ Vec<u8> -> T }``.
-    span_map: ByteSpanTokenMap<T>,
+    span_map: SpanTokenMap<T>,
 }
 
-impl<T: TokenType> From<ByteSpanTokenMap<T>> for SpecialWordsTokenVocab<T> {
-    fn from(span_map: ByteSpanTokenMap<T>) -> Self {
+impl<T: TokenType> From<SpanTokenMap<T>> for SpecialWordsTokenVocab<T> {
+    fn from(span_map: SpanTokenMap<T>) -> Self {
         Self::new(span_map)
     }
 }
 
 impl<T: TokenType> SpecialWordsTokenVocab<T> {
     /// Create a new special words vocab.
-    pub fn new(span_map: ByteSpanTokenMap<T>) -> Self {
+    pub fn new(span_map: SpanTokenMap<T>) -> Self {
         Self { span_map }
     }
 
@@ -36,7 +36,7 @@ impl<T: TokenType> SpecialWordsTokenVocab<T> {
     }
 
     /// Get the span => token map.
-    pub fn span_map(&self) -> &ByteSpanTokenMap<T> {
+    pub fn span_map(&self) -> &SpanTokenMap<T> {
         &self.span_map
     }
 


### PR DESCRIPTION
- Refactored and renamed `ByteSpanTokenMap` to `SpanTokenMap` for improved clarity and consistency.
- Restructured vocabularies to enhance validation and compatibility.
- Introduced `try_validate_pair_map` to ensure `ByteTokenTable` and `PairTokenMap` compatibility.
- Deprecated `new` constructors in favor of `init` methods.
- Updated `UnifiedTokenVocab` to work seamlessly with the new structure.
- Enhanced modularity within training, encoders, decoders, examples, and documentation.