### PR TITLE
Refactor segmentation, encoders, and vocabularies for terminology con…

### DIFF
--- a/crates/wordchuck/examples/token-cli/src/main.rs
+++ b/crates/wordchuck/examples/token-cli/src/main.rs
@@ -84,7 +84,7 @@ fn run_load(
     let vocab: Arc<UnifiedTokenVocab<T>> =
         UnifiedTokenVocab::from_span_vocab(segmentation, span_map.into()).into();
 
-    let encoder: UnifiedVocabEncoder<T> = UnifiedVocabEncoder::<T>::new(vocab.clone());
+    let encoder: UnifiedVocabEncoder<T> = UnifiedVocabEncoder::<T>::init(vocab.clone());
     let encoder = ParallelRayonEncoder::new(encoder);
 
     let decoder = DictionaryDecoder::new(vocab.unified_dictionary());

--- a/crates/wordchuck/examples/tokenizer_trainer/src/main.rs
+++ b/crates/wordchuck/examples/tokenizer_trainer/src/main.rs
@@ -128,12 +128,12 @@ fn main() -> anyhow::Result<()> {
     println!("- vocab_size: {:?}", vocab.max_token());
 
     if let Some(path) = args.tiktoken_save_path {
-        save_span_map_to_tiktoken_path(vocab.word_vocab.span_map(), &path)?;
+        save_span_map_to_tiktoken_path(vocab.span_vocab.span_map(), &path)?;
         println!("- tiktoken vocab: {path:?}");
     }
 
     if args.time_encode_decode {
-        let encoder: UnifiedVocabEncoder<T> = UnifiedVocabEncoder::<T>::new(vocab.clone());
+        let encoder: UnifiedVocabEncoder<T> = UnifiedVocabEncoder::<T>::init(vocab.clone());
         let encoder = ParallelRayonEncoder::new(encoder);
 
         let decoder = DictionaryDecoder::new(vocab.unified_dictionary());

--- a/crates/wordchuck/src/decoders/dictionary_decoder.rs
+++ b/crates/wordchuck/src/decoders/dictionary_decoder.rs
@@ -83,7 +83,7 @@ mod tests {
             .expect("training vocab should succeed")
             .into();
 
-        let encoder = UnifiedVocabEncoder::<T>::new(vocab.clone());
+        let encoder = UnifiedVocabEncoder::<T>::init(vocab.clone());
 
         let decoder = DictionaryDecoder::new(vocab.unified_dictionary());
         check_is_send(&decoder);

--- a/crates/wordchuck/src/decoders/pair_decoder.rs
+++ b/crates/wordchuck/src/decoders/pair_decoder.rs
@@ -118,7 +118,7 @@ mod tests {
             .expect("training vocab should succeed")
             .into();
 
-        let encoder = UnifiedVocabEncoder::<T>::new(vocab.clone());
+        let encoder = UnifiedVocabEncoder::<T>::init(vocab.clone());
 
         let decoder =
             PairExpansionDecoder::from_pair_map(byte_table.clone(), &vocab.pair_vocab.pairs());

--- a/crates/wordchuck/src/encoders/token_encoder.rs
+++ b/crates/wordchuck/src/encoders/token_encoder.rs
@@ -15,7 +15,7 @@ pub trait TokenEncoder<T: TokenType>: TokenVocabIndex<T> + Send + Sync {
     fn special_vocab(&self) -> Option<&SpecialWordsTokenVocab<T>>;
 
     /// Split text using the attached pattern and specials.
-    fn split_words<'a>(
+    fn split_spans<'a>(
         &self,
         text: &'a str,
     ) -> Vec<SpanRef<'a>>;
@@ -34,7 +34,7 @@ pub trait TokenEncoder<T: TokenType>: TokenVocabIndex<T> + Send + Sync {
         text: &str,
         tokens: &mut Vec<T>,
     ) {
-        self.split_words(text).into_iter().for_each(|wr| match wr {
+        self.split_spans(text).into_iter().for_each(|wr| match wr {
             SpanRef::Normal(w) => self.encode_append_span(w.as_bytes(), tokens),
             SpanRef::Special(s) => {
                 tokens.push(

--- a/crates/wordchuck/src/lib.rs
+++ b/crates/wordchuck/src/lib.rs
@@ -56,12 +56,12 @@
 //!         .into();
 //!
 //!     if let Some(path) = tiktoken_save_path {
-//!         save_span_map_to_tiktoken_path(&vocab.word_vocab.span_map(), &path)
+//!         save_span_map_to_tiktoken_path(&vocab.span_vocab.span_map(), &path)
 //!             .expect("failed to save tiktoken vocab");
 //!         println!("- tiktoken vocab: {path:?}");
 //!     }
 //!
-//!     let encoder: UnifiedVocabEncoder<T> = UnifiedVocabEncoder::<T>::new(vocab.clone());
+//!     let encoder: UnifiedVocabEncoder<T> = UnifiedVocabEncoder::<T>::init(vocab.clone());
 //!     let encoder = ParallelRayonEncoder::new(encoder);
 //!
 //!     let decoder = DictionaryDecoder::new(vocab.unified_dictionary());

--- a/crates/wordchuck/src/rayon/rayon_decoder.rs
+++ b/crates/wordchuck/src/rayon/rayon_decoder.rs
@@ -119,7 +119,7 @@ mod tests {
             .expect("training vocab should succeed")
             .into();
 
-        let encoder = UnifiedVocabEncoder::<T>::new(vocab.clone());
+        let encoder = UnifiedVocabEncoder::<T>::init(vocab.clone());
 
         let decoder = ParallelRayonDecoder::new(DictionaryDecoder::new(vocab.unified_dictionary()));
         check_is_send(&decoder);

--- a/crates/wordchuck/src/rayon/rayon_encoder.rs
+++ b/crates/wordchuck/src/rayon/rayon_encoder.rs
@@ -54,11 +54,11 @@ where
         self.inner.special_vocab()
     }
 
-    fn split_words<'a>(
+    fn split_spans<'a>(
         &self,
         text: &'a str,
     ) -> Vec<SpanRef<'a>> {
-        self.inner.split_words(text)
+        self.inner.split_spans(text)
     }
 
     fn encode_append_span(
@@ -119,7 +119,7 @@ mod tests {
 
         let special_sample = "hello <|HI|> world";
 
-        let encoder = UnifiedVocabEncoder::<T>::new(vocab.clone());
+        let encoder = UnifiedVocabEncoder::<T>::init(vocab.clone());
         check_is_send(&encoder);
         check_is_sync(&encoder);
 

--- a/crates/wordchuck/src/segmentation/segmentation_config.rs
+++ b/crates/wordchuck/src/segmentation/segmentation_config.rs
@@ -7,7 +7,7 @@ use crate::vocab::special_vocab::SpecialWordsTokenVocab;
 #[derive(Debug, Clone)]
 pub struct SegmentationConfig<T: TokenType> {
     /// Regex pattern for word splitting.
-    pub word_pattern: RegexWrapperPattern,
+    pub pattern: RegexWrapperPattern,
 
     /// Special tokens vocabulary.
     pub specials: SpecialWordsTokenVocab<T>,
@@ -25,20 +25,17 @@ impl<T: TokenType> SegmentationConfig<T> {
     /// Will contain an empty list of specials.
     pub fn from_pattern(word_pattern: RegexWrapperPattern) -> Self {
         Self {
-            word_pattern,
+            pattern: word_pattern,
             specials: SpecialWordsTokenVocab::default(),
         }
     }
 
-    /// Set the word pattern for the text segmentor configuration.
-    pub fn with_word_pattern(
+    /// Set the split pattern for the text segmentor configuration.
+    pub fn with_pattern(
         self,
-        word_pattern: RegexWrapperPattern,
+        pattern: RegexWrapperPattern,
     ) -> Self {
-        Self {
-            word_pattern,
-            ..self
-        }
+        Self { pattern, ..self }
     }
 
     /// Replace special tokens vocabulary.
@@ -79,7 +76,7 @@ impl<T: TokenType> SegmentationConfig<T> {
 
     /// Get the word pattern for the text segmentor configuration.
     pub fn pattern(&self) -> String {
-        self.word_pattern.as_str().to_string()
+        self.pattern.as_str().to_string()
     }
 
     /// Get the special tokens vocabulary for the text segmentor configuration.

--- a/crates/wordchuck/src/segmentation/text_segmentor.rs
+++ b/crates/wordchuck/src/segmentation/text_segmentor.rs
@@ -64,7 +64,7 @@ impl TextSegmentor {
 
     /// Create a new text segmentor with the given configuration.
     pub fn from_config<T: TokenType>(config: SegmentationConfig<T>) -> Self {
-        let word_sup = maybe_parallel_regex_supplier(config.word_pattern);
+        let word_sup = maybe_parallel_regex_supplier(config.pattern);
         let specials = if config.specials.is_empty() {
             None
         } else {

--- a/crates/wordchuck/src/training/bpe_trainer.rs
+++ b/crates/wordchuck/src/training/bpe_trainer.rs
@@ -441,7 +441,7 @@ mod tests {
 
         let vocab: UnifiedTokenVocab<T> = trainer.train(byte_table.clone()).unwrap();
 
-        let encoder = UnifiedVocabEncoder::<T>::new(vocab.clone().into());
+        let encoder = UnifiedVocabEncoder::<T>::init(vocab.clone().into());
         check_is_send(&encoder);
         check_is_sync(&encoder);
 

--- a/crates/wordchuck/src/vocab/pair_vocab.rs
+++ b/crates/wordchuck/src/vocab/pair_vocab.rs
@@ -2,7 +2,7 @@
 
 use crate::decoders::TokenDecoder;
 use crate::decoders::pair_decoder::PairExpansionDecoder;
-use crate::types::{PairTokenMap, TokenType};
+use crate::types::{Pair, PairTokenMap, TokenType};
 use crate::vocab::byte_table::ByteTokenTable;
 use crate::vocab::vocab_index::TokenVocabIndex;
 use ahash::AHashSet;
@@ -105,6 +105,14 @@ impl<T: TokenType> PairTokenMapVocab<T> {
                 .values()
                 .map(move |&t| (decoder.try_decode_to_bytes([t]).unwrap(), t)),
         )
+    }
+
+    /// Looks up a pair.
+    pub fn lookup_pair(
+        &self,
+        pair: &Pair<T>,
+    ) -> Option<&T> {
+        self.pairs.get(pair)
     }
 }
 


### PR DESCRIPTION
…sistency and improved API clarity.

- Renamed `word_pattern` to `pattern` for clear generalization in `SegmentationConfig`.
- Replaced `word_vocab` with `span_vocab` across `UnifiedTokenVocab` and related implementations.
- Deprecated `new` constructors in favor of `init` methods for `UnifiedVocabEncoder` and vocabularies.
- Introduced `lookup_token` and `lookup_pair` methods in vocabularies for simplified token retrieval.
- Updated examples, tests, and documentation to align with new API changes.