### PR TITLE
Simplify TextSegmentor lifecycle; isolate pool builder.

### DIFF
--- a/crates/wordchuck/examples/tokenizer_trainer/src/main.rs
+++ b/crates/wordchuck/examples/tokenizer_trainer/src/main.rs
@@ -9,6 +9,7 @@ use std::time::Duration;
 use wordchuck::decoders::{DictionaryDecoder, TokenDecoder};
 use wordchuck::encoders::{TokenEncoder, UnifiedVocabEncoder};
 use wordchuck::rayon::{ParallelRayonDecoder, ParallelRayonEncoder};
+use wordchuck::regex::default_regex_supplier;
 use wordchuck::training::BinaryPairVocabTrainerOptions;
 use wordchuck::vocab::byte_table::ByteTokenTable;
 use wordchuck::vocab::io::tiktoken_io::save_span_map_to_tiktoken_path;
@@ -133,7 +134,8 @@ fn main() -> anyhow::Result<()> {
     }
 
     if args.time_encode_decode {
-        let encoder: UnifiedVocabEncoder<T> = UnifiedVocabEncoder::<T>::init(vocab.clone());
+        let encoder: UnifiedVocabEncoder<T> =
+            UnifiedVocabEncoder::<T>::init(vocab.clone(), default_regex_supplier);
         let encoder = ParallelRayonEncoder::new(encoder);
 
         let decoder = DictionaryDecoder::new(vocab.unified_dictionary());

--- a/crates/wordchuck/src/decoders/dictionary_decoder.rs
+++ b/crates/wordchuck/src/decoders/dictionary_decoder.rs
@@ -50,6 +50,7 @@ mod tests {
     use super::*;
     use crate::encoders::token_encoder::TokenEncoder;
     use crate::encoders::unified_encoder::UnifiedVocabEncoder;
+    use crate::regex::default_regex_supplier;
     use crate::training::bpe_trainer::BinaryPairVocabTrainerOptions;
     use crate::types::{check_is_send, check_is_sync};
     use crate::vocab::byte_table::ByteTokenTable;
@@ -83,7 +84,7 @@ mod tests {
             .expect("training vocab should succeed")
             .into();
 
-        let encoder = UnifiedVocabEncoder::<T>::init(vocab.clone());
+        let encoder = UnifiedVocabEncoder::<T>::init(vocab.clone(), default_regex_supplier);
 
         let decoder = DictionaryDecoder::new(vocab.unified_dictionary());
         check_is_send(&decoder);

--- a/crates/wordchuck/src/decoders/pair_decoder.rs
+++ b/crates/wordchuck/src/decoders/pair_decoder.rs
@@ -85,6 +85,7 @@ mod tests {
     use super::*;
     use crate::encoders::token_encoder::TokenEncoder;
     use crate::encoders::unified_encoder::UnifiedVocabEncoder;
+    use crate::regex::default_regex_supplier;
     use crate::training::bpe_trainer::BinaryPairVocabTrainerOptions;
     use crate::types::{check_is_send, check_is_sync};
     use crate::vocab::byte_table::ByteTokenTable;
@@ -118,7 +119,7 @@ mod tests {
             .expect("training vocab should succeed")
             .into();
 
-        let encoder = UnifiedVocabEncoder::<T>::init(vocab.clone());
+        let encoder = UnifiedVocabEncoder::<T>::init(vocab.clone(), default_regex_supplier);
 
         let decoder =
             PairExpansionDecoder::from_pair_map(byte_table.clone(), &vocab.pair_vocab.pairs());

--- a/crates/wordchuck/src/encoders/token_encoder.rs
+++ b/crates/wordchuck/src/encoders/token_encoder.rs
@@ -12,7 +12,7 @@ pub trait TokenEncoder<T: TokenType>: TokenVocabIndex<T> + Send + Sync {
     fn pattern(&self) -> String;
 
     /// Return the special vocabulary, if any.
-    fn special_vocab(&self) -> Option<&SpecialWordsTokenVocab<T>>;
+    fn special_vocab(&self) -> &SpecialWordsTokenVocab<T>;
 
     /// Split text using the attached pattern and specials.
     fn split_spans<'a>(
@@ -37,12 +37,7 @@ pub trait TokenEncoder<T: TokenType>: TokenVocabIndex<T> + Send + Sync {
         self.split_spans(text).into_iter().for_each(|wr| match wr {
             SpanRef::Normal(w) => self.encode_append_span(w.as_bytes(), tokens),
             SpanRef::Special(s) => {
-                tokens.push(
-                    self.special_vocab()
-                        .unwrap()
-                        .lookup_token(s.as_bytes())
-                        .unwrap(),
-                );
+                tokens.push(self.special_vocab().lookup_token(s.as_bytes()).unwrap());
             }
         });
     }

--- a/crates/wordchuck/src/lib.rs
+++ b/crates/wordchuck/src/lib.rs
@@ -16,6 +16,7 @@
 //! use wordchuck::encoders::UnifiedVocabEncoder;
 //! use wordchuck::decoders::DictionaryDecoder;
 //! use wordchuck::rayon::{ParallelRayonEncoder, ParallelRayonDecoder};
+//! use wordchuck::regex::default_regex_supplier;
 //! use std::sync::Arc;
 //!
 //! fn example<I, S>(
@@ -61,7 +62,9 @@
 //!         println!("- tiktoken vocab: {path:?}");
 //!     }
 //!
-//!     let encoder: UnifiedVocabEncoder<T> = UnifiedVocabEncoder::<T>::init(vocab.clone());
+//!     let encoder: UnifiedVocabEncoder<T> = UnifiedVocabEncoder::<T>::init(
+//!         vocab.clone(),
+//!         default_regex_supplier);
 //!     let encoder = ParallelRayonEncoder::new(encoder);
 //!
 //!     let decoder = DictionaryDecoder::new(vocab.unified_dictionary());

--- a/crates/wordchuck/src/rayon/rayon_decoder.rs
+++ b/crates/wordchuck/src/rayon/rayon_decoder.rs
@@ -85,6 +85,7 @@ mod tests {
     use crate::decoders::DictionaryDecoder;
     use crate::encoders::UnifiedVocabEncoder;
     use crate::encoders::token_encoder::TokenEncoder;
+    use crate::regex::default_regex_supplier;
     use crate::training::bpe_trainer::BinaryPairVocabTrainerOptions;
     use crate::types::{check_is_send, check_is_sync};
     use crate::vocab::byte_table::ByteTokenTable;
@@ -119,7 +120,7 @@ mod tests {
             .expect("training vocab should succeed")
             .into();
 
-        let encoder = UnifiedVocabEncoder::<T>::init(vocab.clone());
+        let encoder = UnifiedVocabEncoder::<T>::init(vocab.clone(), default_regex_supplier);
 
         let decoder = ParallelRayonDecoder::new(DictionaryDecoder::new(vocab.unified_dictionary()));
         check_is_send(&decoder);

--- a/crates/wordchuck/src/rayon/rayon_encoder.rs
+++ b/crates/wordchuck/src/rayon/rayon_encoder.rs
@@ -50,7 +50,7 @@ where
         self.inner.pattern()
     }
 
-    fn special_vocab(&self) -> Option<&SpecialWordsTokenVocab<T>> {
+    fn special_vocab(&self) -> &SpecialWordsTokenVocab<T> {
         self.inner.special_vocab()
     }
 
@@ -83,6 +83,7 @@ mod tests {
     use crate::decoders::{DictionaryDecoder, TokenDecoder};
     use crate::encoders::{TokenEncoder, UnifiedVocabEncoder};
     use crate::rayon::rayon_encoder::ParallelRayonEncoder;
+    use crate::regex::default_regex_supplier;
     use crate::training::BinaryPairVocabTrainerOptions;
     use crate::types::{check_is_send, check_is_sync};
     use crate::vocab::byte_table::ByteTokenTable;
@@ -119,7 +120,7 @@ mod tests {
 
         let special_sample = "hello <|HI|> world";
 
-        let encoder = UnifiedVocabEncoder::<T>::init(vocab.clone());
+        let encoder = UnifiedVocabEncoder::<T>::init(vocab.clone(), default_regex_supplier);
         check_is_send(&encoder);
         check_is_sync(&encoder);
 

--- a/crates/wordchuck/src/regex/exact_match_union.rs
+++ b/crates/wordchuck/src/regex/exact_match_union.rs
@@ -1,6 +1,6 @@
 //! Exact Match Union Patterns
 
-use crate::regex::regex_wrapper::{RegexWrapper, RegexWrapperPattern};
+use crate::regex::regex_wrapper::RegexWrapperPattern;
 
 /// Create a union pattern of exact matches.
 ///
@@ -13,16 +13,10 @@ pub fn exact_match_union_regex_pattern<S: AsRef<str>>(alts: &[S]) -> RegexWrappe
     RegexWrapperPattern::Basic(format!("({})", parts.join("|")))
 }
 
-/// Create a union pattern of exact matches, compiled into a [`RegexWrapper`].
-///
-/// See: [`exact_match_union_regex_pattern`]
-pub fn exact_match_union_regex_wrapper<S: AsRef<str>>(alts: &[S]) -> RegexWrapper {
-    exact_match_union_regex_pattern(alts).compile().unwrap()
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::regex::RegexWrapper;
 
     #[test]
     fn test_fixed_alternative_list() {
@@ -31,7 +25,9 @@ mod tests {
         let pattern = exact_match_union_regex_pattern(&alternatives);
         assert_eq!(pattern.as_str(), r"(apple|\[x\]|boat)");
 
-        let re = exact_match_union_regex_wrapper(&alternatives);
+        let re: RegexWrapper = exact_match_union_regex_pattern(&alternatives)
+            .compile()
+            .unwrap();
 
         let text = "apple 123 [x] xyz boat";
         assert_eq!(re.find_iter(text).count(), 3);

--- a/crates/wordchuck/src/regex/mod.rs
+++ b/crates/wordchuck/src/regex/mod.rs
@@ -33,10 +33,10 @@
 //!
 //! The chosen solution to this is the combination of:
 //! * [`RegexSupplier`] / [`RegexSupplierHandle`]
-//! * [`maybe_parallel_regex_supplier`].
+//! * [`regex_pool_supplier`].
 //!
 //! Users of a [`RegexWrapper`] that *may* be under heavy thread contention should use
-//! [`maybe_parallel_regex_supplier`]; which in some build environments will provide
+//! [`regex_pool_supplier`]; which in some build environments will provide
 //! a thread local clone regex supplier, and in some, a simple clone implementation.
 
 pub mod exact_match_union;
@@ -49,23 +49,20 @@ pub mod regex_wrapper;
 pub use regex_supplier::{RegexSupplier, RegexSupplierHandle};
 pub use regex_wrapper::{ErrorWrapper, RegexWrapper, RegexWrapperHandle, RegexWrapperPattern};
 
+/// Build a [`RegexSupplierHandle`].
+pub fn default_regex_supplier(regex: RegexWrapperHandle) -> RegexSupplierHandle {
+    regex
+}
+
 /// Build a regex supplier for (potentially) parallel execution.
 ///
 /// Users of a [`RegexWrapper`] that *may* be under heavy thread contention should use
-/// [`maybe_parallel_regex_supplier`]; which in some build environments will provide
+/// [`regex_pool_supplier`]; which in some build environments will provide
 /// a thread local clone regex supplier, and in some, a simple clone implementation.
-pub fn maybe_parallel_regex_supplier<R>(regex: R) -> RegexSupplierHandle
-where
-    R: Into<RegexWrapperHandle>,
-{
-    /*
-    let regex = regex.into();
-
+pub fn regex_pool_supplier(regex: RegexWrapperHandle) -> RegexSupplierHandle {
     #[cfg(feature = "std")]
     return alloc::sync::Arc::new(regex_pool::RegexWrapperPool::new(regex));
 
     #[cfg(not(feature = "std"))]
-
-     */
-    regex.into()
+    regex
 }

--- a/crates/wordchuck/src/segmentation/segmentation_config.rs
+++ b/crates/wordchuck/src/segmentation/segmentation_config.rs
@@ -23,19 +23,28 @@ impl<T: TokenType> SegmentationConfig<T> {
     /// Create a new text segmentor configuration with the given word pattern.
     ///
     /// Will contain an empty list of specials.
-    pub fn from_pattern(word_pattern: RegexWrapperPattern) -> Self {
+    pub fn from_pattern<P>(pattern: P) -> Self
+    where
+        P: Into<RegexWrapperPattern>,
+    {
         Self {
-            pattern: word_pattern,
+            pattern: pattern.into(),
             specials: SpecialWordsTokenVocab::default(),
         }
     }
 
     /// Set the split pattern for the text segmentor configuration.
-    pub fn with_pattern(
+    pub fn with_pattern<P>(
         self,
-        pattern: RegexWrapperPattern,
-    ) -> Self {
-        Self { pattern, ..self }
+        pattern: P,
+    ) -> Self
+    where
+        P: Into<RegexWrapperPattern>,
+    {
+        Self {
+            pattern: pattern.into(),
+            ..self
+        }
     }
 
     /// Replace special tokens vocabulary.
@@ -80,11 +89,7 @@ impl<T: TokenType> SegmentationConfig<T> {
     }
 
     /// Get the special tokens vocabulary for the text segmentor configuration.
-    pub fn special_vocab(&self) -> Option<&SpecialWordsTokenVocab<T>> {
-        if self.specials.is_empty() {
-            None
-        } else {
-            Some(&self.specials)
-        }
+    pub fn special_vocab(&self) -> &SpecialWordsTokenVocab<T> {
+        &self.specials
     }
 }

--- a/crates/wordchuck/src/training/bpe_trainer.rs
+++ b/crates/wordchuck/src/training/bpe_trainer.rs
@@ -391,6 +391,7 @@ mod tests {
     use crate::decoders::token_decoder::TokenDecoder;
     use crate::encoders::token_encoder::TokenEncoder;
     use crate::encoders::unified_encoder::UnifiedVocabEncoder;
+    use crate::regex::default_regex_supplier;
     use crate::training::bpe_trainer::{BinaryPairVocabTrainerOptions, MergeJob};
     use crate::types::{check_is_send, check_is_sync};
     use crate::vocab::TokenVocabIndex;
@@ -441,7 +442,7 @@ mod tests {
 
         let vocab: UnifiedTokenVocab<T> = trainer.train(byte_table.clone()).unwrap();
 
-        let encoder = UnifiedVocabEncoder::<T>::init(vocab.clone().into());
+        let encoder = UnifiedVocabEncoder::<T>::init(vocab.clone().into(), default_regex_supplier);
         check_is_send(&encoder);
         check_is_sync(&encoder);
 

--- a/crates/wordchuck/src/training/text_span_counter.rs
+++ b/crates/wordchuck/src/training/text_span_counter.rs
@@ -154,9 +154,10 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::regex::{RegexWrapperPattern, maybe_parallel_regex_supplier};
+    use crate::regex::RegexWrapperPattern;
     use crate::training::token_span_buffer::TokenSpanBuf;
     use crate::types::{CountType, StringChunkType};
+    use std::sync::Arc;
 
     const PATTERN: &str = r"\w+";
 
@@ -167,10 +168,8 @@ mod tests {
 
     #[test]
     fn test_word_counter() {
-        let mut wc: TextSpanCounter<String, u64> = TextSpanCounter::new(
-            maybe_parallel_regex_supplier(get_regex()),
-            TextSpanCounterOptions::default(),
-        );
+        let mut wc: TextSpanCounter<String, u64> =
+            TextSpanCounter::new(Arc::new(get_regex()), TextSpanCounterOptions::default());
 
         let samples = vec!["Hello world", "Foo world bar world"];
         wc.update_from_samples(samples.iter());
@@ -205,10 +204,8 @@ mod tests {
 
         let byte_table: ByteTokenTable<T> = Default::default();
 
-        let mut word_counts = TextSpanCounter::<K, C>::new(
-            maybe_parallel_regex_supplier(get_regex()),
-            TextSpanCounterOptions::default(),
-        );
+        let mut word_counts =
+            TextSpanCounter::<K, C>::new(Arc::new(get_regex()), TextSpanCounterOptions::default());
 
         let samples = vec!["Hello world", "Foo world bar world"];
 

--- a/crates/wordchuck/src/vocab/byte_table.rs
+++ b/crates/wordchuck/src/vocab/byte_table.rs
@@ -132,7 +132,7 @@ impl<T: TokenType> ByteTokenTable<T> {
     }
 
     /// Generate all ``(Vec<u8>, T)`` pairs in the vocabulary.
-    pub fn to_span_pairs(&self) -> impl Iterator<Item = (Vec<u8>, T)> {
+    pub fn span_pairs(&self) -> impl Iterator<Item = (Vec<u8>, T)> {
         self.byte_to_token
             .iter()
             .enumerate()

--- a/crates/wordchuck/src/vocab/pair_vocab.rs
+++ b/crates/wordchuck/src/vocab/pair_vocab.rs
@@ -97,10 +97,10 @@ impl<T: TokenType> PairTokenMapVocab<T> {
     /// Generate all ``(Vec<u8>, T)`` pairs in the vocabulary.
     ///
     /// This includes the pairs from the `ByteTable`.
-    pub fn to_span_pairs(&self) -> impl Iterator<Item = (Vec<u8>, T)> {
+    pub fn span_pairs(&self) -> impl Iterator<Item = (Vec<u8>, T)> {
         let decoder = PairExpansionDecoder::from_pair_map(self.byte_table().clone(), self.pairs());
 
-        self.byte_table.to_span_pairs().chain(
+        self.byte_table.span_pairs().chain(
             self.pairs
                 .values()
                 .map(move |&t| (decoder.try_decode_to_bytes([t]).unwrap(), t)),

--- a/crates/wordchuck/src/vocab/span_vocab.rs
+++ b/crates/wordchuck/src/vocab/span_vocab.rs
@@ -60,7 +60,7 @@ pub fn try_validate_span_map<T>(
 where
     T: TokenType,
 {
-    for (span, token) in byte_table.to_span_pairs() {
+    for (span, token) in byte_table.span_pairs() {
         let b = span[0];
 
         if let Some(&map_token) = span_map.get(&span)
@@ -87,7 +87,7 @@ impl<T: TokenType> SpanTokenVocab<T> {
     {
         let byte_table = byte_table.into();
 
-        let span_map: SpanTokenMap<T> = byte_table.to_span_pairs().collect();
+        let span_map: SpanTokenMap<T> = byte_table.span_pairs().collect();
 
         Self::init(byte_table, span_map).unwrap()
     }
@@ -122,7 +122,7 @@ impl<T: TokenType> SpanTokenVocab<T> {
     /// Build word vocabulary from a [`PairTokenMapVocab<T>`].
     pub fn from_pair_vocab(pair_vocab: &PairTokenMapVocab<T>) -> Self {
         let byte_table: Arc<ByteTokenTable<T>> = pair_vocab.byte_table().clone();
-        let span_map: SpanTokenMap<T> = pair_vocab.to_span_pairs().collect();
+        let span_map: SpanTokenMap<T> = pair_vocab.span_pairs().collect();
 
         Self::init(byte_table, span_map).unwrap()
     }
@@ -141,7 +141,7 @@ impl<T: TokenType> SpanTokenVocab<T> {
         let byte_table = byte_table.into();
         try_validate_span_map(&byte_table, &span_map)?;
 
-        span_map.extend(byte_table.to_span_pairs());
+        span_map.extend(byte_table.span_pairs());
 
         Ok(Self {
             byte_table,
@@ -160,7 +160,7 @@ impl<T: TokenType> SpanTokenVocab<T> {
     }
 
     /// Iterate over the span => token pairs.
-    pub fn to_span_pairs(&self) -> impl Iterator<Item = (Vec<u8>, T)> {
+    pub fn span_pairs(&self) -> impl Iterator<Item = (Vec<u8>, T)> {
         self.span_map
             .iter()
             .map(|(chunk, &token)| (chunk.clone(), token))

--- a/crates/wordchuck/src/vocab/special_vocab.rs
+++ b/crates/wordchuck/src/vocab/special_vocab.rs
@@ -40,6 +40,11 @@ impl<T: TokenType> SpecialWordsTokenVocab<T> {
         &self.span_map
     }
 
+    /// Get an iterator over the span slices.
+    pub fn spans(&self) -> impl Iterator<Item = &[u8]> {
+        self.span_map.keys().map(|chunk| chunk.as_slice())
+    }
+
     /// Add a word to the vocab.
     pub fn add_str_word(
         &mut self,
@@ -74,7 +79,7 @@ impl<T: TokenType> SpecialWordsTokenVocab<T> {
     }
 
     /// Generate all ``(Vec<u8>, T)`` pairs in the vocabulary.
-    pub fn to_span_pairs(&self) -> impl Iterator<Item = (Vec<u8>, T)> {
+    pub fn span_pairs(&self) -> impl Iterator<Item = (Vec<u8>, T)> {
         self.span_map
             .iter()
             .map(|(chunk, &token)| (chunk.clone(), token))

--- a/crates/wordchuck/src/vocab/unified_vocab.rs
+++ b/crates/wordchuck/src/vocab/unified_vocab.rs
@@ -37,10 +37,7 @@ impl<T: TokenType> UnifiedTokenVocab<T> {
         segmentation: SegmentationConfig<T>,
         pair_vocab: PairTokenMapVocab<T>,
     ) -> Self {
-        let word_vocab = pair_vocab
-            .to_span_pairs()
-            .collect::<SpanTokenMap<T>>()
-            .into();
+        let word_vocab = pair_vocab.span_pairs().collect::<SpanTokenMap<T>>().into();
         Self::from_span_vocab(segmentation, word_vocab)
     }
 
@@ -103,17 +100,15 @@ impl<T: TokenType> UnifiedTokenVocab<T> {
             tmp.insert(chunk.clone(), token);
         });
 
-        for (span, token) in self.pair_vocab.to_span_pairs() {
+        for (span, token) in self.pair_vocab.span_pairs() {
             if tmp.contains_key(&span) {
                 continue;
             }
             tmp.insert(span, token);
         }
 
-        if let Some(specials) = &self.segmentation.special_vocab() {
-            for (chunk, &t) in specials.span_map().iter() {
-                tmp.insert(chunk.clone(), t);
-            }
+        for (span, t) in self.segmentation.special_vocab().span_pairs() {
+            tmp.insert(span, t);
         }
 
         tmp.into_iter()


### PR DESCRIPTION
Refactor regex handling and standardize span vocabulary methods for improved readability and consistency across segmentation, encoders, and vocabularies. (#82)

- Replaced `to_span_pairs` with `span_pairs` for naming consistency across vocabularies.
- Introduced `default_regex_supplier` and refactored regex handling to simplify initialization.
- Updated `UnifiedVocabEncoder` and `TextSegmentor` to accept external regex suppliers.
- Streamlined special vocab handling by replacing `Option` with direct references.
- Updated constructors in tests and examples to align with new API changes.