### PR TITLE
Cleanup Encoder build lifecycle.

### DIFF
--- a/crates/wordchuck/examples/token-cli/src/main.rs
+++ b/crates/wordchuck/examples/token-cli/src/main.rs
@@ -6,7 +6,7 @@ use similar::{ChangeTag, TextDiff};
 use std::sync::Arc;
 use std::time::Duration;
 use wordchuck::decoders::{DictionaryDecoder, TokenDecoder};
-use wordchuck::encoders::{TokenEncoder, UnifiedVocabEncoder};
+use wordchuck::encoders::{MergeHeapVocabEncoder, TokenEncoder};
 use wordchuck::rayon::{ParallelRayonDecoder, ParallelRayonEncoder};
 use wordchuck::regex::{RegexWrapperPattern, regex_pool_supplier};
 use wordchuck::segmentation::{SegmentationConfig, TextSegmentor};
@@ -84,11 +84,11 @@ fn run_load(
     let vocab: Arc<UnifiedTokenVocab<T>> =
         UnifiedTokenVocab::from_span_vocab(segmentation, span_map.into()).into();
 
-    let encoder: UnifiedVocabEncoder<T> =
-        UnifiedVocabEncoder::<T>::init(vocab.clone(), regex_pool_supplier);
+    let encoder: MergeHeapVocabEncoder<T> =
+        MergeHeapVocabEncoder::<T>::init(vocab.clone(), regex_pool_supplier);
     let encoder = ParallelRayonEncoder::new(encoder);
 
-    let decoder = DictionaryDecoder::new(vocab.unified_dictionary());
+    let decoder = DictionaryDecoder::from_unified_vocab(vocab.clone());
     let decoder = ParallelRayonDecoder::new(decoder);
 
     let shards: Vec<usize> = vec![0];

--- a/crates/wordchuck/examples/tokenizer_trainer/src/main.rs
+++ b/crates/wordchuck/examples/tokenizer_trainer/src/main.rs
@@ -7,7 +7,7 @@ use std::collections::HashSet;
 use std::sync::Arc;
 use std::time::Duration;
 use wordchuck::decoders::{DictionaryDecoder, TokenDecoder};
-use wordchuck::encoders::{TokenEncoder, UnifiedVocabEncoder};
+use wordchuck::encoders::{MergeHeapVocabEncoder, TokenEncoder};
 use wordchuck::rayon::{ParallelRayonDecoder, ParallelRayonEncoder};
 use wordchuck::regex::default_regex_supplier;
 use wordchuck::training::BinaryPairVocabTrainerOptions;
@@ -134,11 +134,11 @@ fn main() -> anyhow::Result<()> {
     }
 
     if args.time_encode_decode {
-        let encoder: UnifiedVocabEncoder<T> =
-            UnifiedVocabEncoder::<T>::init(vocab.clone(), default_regex_supplier);
+        let encoder: MergeHeapVocabEncoder<T> =
+            MergeHeapVocabEncoder::<T>::init(vocab.clone(), default_regex_supplier);
         let encoder = ParallelRayonEncoder::new(encoder);
 
-        let decoder = DictionaryDecoder::new(vocab.unified_dictionary());
+        let decoder = DictionaryDecoder::from_unified_vocab(vocab);
         let decoder = ParallelRayonDecoder::new(decoder);
 
         let mut samples = Vec::new();

--- a/crates/wordchuck/src/encoders/merge_heap_encoder.rs
+++ b/crates/wordchuck/src/encoders/merge_heap_encoder.rs
@@ -11,7 +11,7 @@ use alloc::sync::Arc;
 
 /// A Chunk/Pair Scanning [`TokenEncoder`].
 #[derive(Clone)]
-pub struct UnifiedVocabEncoder<T: TokenType> {
+pub struct MergeHeapVocabEncoder<T: TokenType> {
     /// Data for the encoders.
     pub data: Arc<UnifiedTokenVocab<T>>,
 
@@ -19,7 +19,7 @@ pub struct UnifiedVocabEncoder<T: TokenType> {
     pub segmentor: TextSegmentor,
 }
 
-impl<T: TokenType> UnifiedVocabEncoder<T> {
+impl<T: TokenType> MergeHeapVocabEncoder<T> {
     /// Construct an encoder from data.
     pub fn init<F>(
         data: Arc<UnifiedTokenVocab<T>>,
@@ -59,7 +59,7 @@ impl<T: TokenType> UnifiedVocabEncoder<T> {
     }
 }
 
-impl<T: TokenType> TokenVocabIndex<T> for UnifiedVocabEncoder<T> {
+impl<T: TokenType> TokenVocabIndex<T> for MergeHeapVocabEncoder<T> {
     fn unordered_tokens_iter(&self) -> impl Iterator<Item = T> {
         self.data.unordered_tokens_iter()
     }
@@ -69,7 +69,7 @@ impl<T: TokenType> TokenVocabIndex<T> for UnifiedVocabEncoder<T> {
     }
 }
 
-impl<T: TokenType> TokenEncoder<T> for UnifiedVocabEncoder<T> {
+impl<T: TokenType> TokenEncoder<T> for MergeHeapVocabEncoder<T> {
     fn pattern(&self) -> String {
         self.data.segmentation.pattern()
     }
@@ -173,8 +173,8 @@ impl<T: TokenType> TokenEncoder<T> for UnifiedVocabEncoder<T> {
 mod tests {
     use crate::decoders::DictionaryDecoder;
     use crate::decoders::token_decoder::TokenDecoder;
+    use crate::encoders::merge_heap_encoder::MergeHeapVocabEncoder;
     use crate::encoders::token_encoder::TokenEncoder;
-    use crate::encoders::unified_encoder::UnifiedVocabEncoder;
     use crate::regex::default_regex_supplier;
     use crate::training::bpe_trainer::BinaryPairVocabTrainerOptions;
     use crate::types::{check_is_send, check_is_sync};
@@ -213,13 +213,13 @@ mod tests {
 
         let special_sample = "hello <|HI|> world";
 
-        let encoder = UnifiedVocabEncoder::<T>::init(vocab.clone(), default_regex_supplier);
+        let encoder = MergeHeapVocabEncoder::<T>::init(vocab.clone(), default_regex_supplier);
         check_is_send(&encoder);
         check_is_sync(&encoder);
 
         assert_eq!(encoder.max_token(), 3000);
 
-        let decoder = DictionaryDecoder::new(vocab.unified_dictionary());
+        let decoder = DictionaryDecoder::from_unified_vocab(vocab);
         check_is_send(&decoder);
         check_is_sync(&decoder);
 

--- a/crates/wordchuck/src/encoders/mod.rs
+++ b/crates/wordchuck/src/encoders/mod.rs
@@ -1,7 +1,7 @@
 //! # Token Encoders
 
+pub mod merge_heap_encoder;
 pub mod token_encoder;
-pub mod unified_encoder;
 
+pub use merge_heap_encoder::MergeHeapVocabEncoder;
 pub use token_encoder::TokenEncoder;
-pub use unified_encoder::UnifiedVocabEncoder;

--- a/crates/wordchuck/src/lib.rs
+++ b/crates/wordchuck/src/lib.rs
@@ -13,7 +13,7 @@
 //! use wordchuck::vocab::io::tiktoken_io::save_span_map_to_tiktoken_path;
 //! use wordchuck::vocab::public::openai::patterns::OA_GPT3_CL100K_WORD_PATTERN;
 //! use wordchuck::vocab::{ByteTokenTable, UnifiedTokenVocab};
-//! use wordchuck::encoders::UnifiedVocabEncoder;
+//! use wordchuck::encoders::MergeHeapVocabEncoder;
 //! use wordchuck::decoders::DictionaryDecoder;
 //! use wordchuck::rayon::{ParallelRayonEncoder, ParallelRayonDecoder};
 //! use wordchuck::regex::default_regex_supplier;
@@ -62,12 +62,13 @@
 //!         println!("- tiktoken vocab: {path:?}");
 //!     }
 //!
-//!     let encoder: UnifiedVocabEncoder<T> = UnifiedVocabEncoder::<T>::init(
+//!     let encoder: MergeHeapVocabEncoder<T> = MergeHeapVocabEncoder::<T>::init(
 //!         vocab.clone(),
-//!         default_regex_supplier);
+//!         default_regex_supplier
+//!     );
 //!     let encoder = ParallelRayonEncoder::new(encoder);
 //!
-//!     let decoder = DictionaryDecoder::new(vocab.unified_dictionary());
+//!     let decoder = DictionaryDecoder::from_unified_vocab(vocab.clone());
 //!     let decoder = ParallelRayonDecoder::new(decoder);
 //! }
 //! ```

--- a/crates/wordchuck/src/rayon/rayon_decoder.rs
+++ b/crates/wordchuck/src/rayon/rayon_decoder.rs
@@ -83,7 +83,7 @@ where
 mod tests {
     use super::*;
     use crate::decoders::DictionaryDecoder;
-    use crate::encoders::UnifiedVocabEncoder;
+    use crate::encoders::MergeHeapVocabEncoder;
     use crate::encoders::token_encoder::TokenEncoder;
     use crate::regex::default_regex_supplier;
     use crate::training::bpe_trainer::BinaryPairVocabTrainerOptions;
@@ -120,9 +120,9 @@ mod tests {
             .expect("training vocab should succeed")
             .into();
 
-        let encoder = UnifiedVocabEncoder::<T>::init(vocab.clone(), default_regex_supplier);
+        let encoder = MergeHeapVocabEncoder::<T>::init(vocab.clone(), default_regex_supplier);
 
-        let decoder = ParallelRayonDecoder::new(DictionaryDecoder::new(vocab.unified_dictionary()));
+        let decoder = ParallelRayonDecoder::new(DictionaryDecoder::from_unified_vocab(vocab));
         check_is_send(&decoder);
         check_is_sync(&decoder);
 

--- a/crates/wordchuck/src/rayon/rayon_encoder.rs
+++ b/crates/wordchuck/src/rayon/rayon_encoder.rs
@@ -81,7 +81,7 @@ where
 #[cfg(test)]
 mod tests {
     use crate::decoders::{DictionaryDecoder, TokenDecoder};
-    use crate::encoders::{TokenEncoder, UnifiedVocabEncoder};
+    use crate::encoders::{MergeHeapVocabEncoder, TokenEncoder};
     use crate::rayon::rayon_encoder::ParallelRayonEncoder;
     use crate::regex::default_regex_supplier;
     use crate::training::BinaryPairVocabTrainerOptions;
@@ -120,7 +120,7 @@ mod tests {
 
         let special_sample = "hello <|HI|> world";
 
-        let encoder = UnifiedVocabEncoder::<T>::init(vocab.clone(), default_regex_supplier);
+        let encoder = MergeHeapVocabEncoder::<T>::init(vocab.clone(), default_regex_supplier);
         check_is_send(&encoder);
         check_is_sync(&encoder);
 
@@ -130,7 +130,7 @@ mod tests {
 
         assert_eq!(encoder.max_token(), 3000);
 
-        let decoder = DictionaryDecoder::new(vocab.unified_dictionary());
+        let decoder = DictionaryDecoder::from_unified_vocab(vocab);
         check_is_send(&decoder);
         check_is_sync(&decoder);
 

--- a/crates/wordchuck/src/training/bpe_trainer.rs
+++ b/crates/wordchuck/src/training/bpe_trainer.rs
@@ -389,8 +389,8 @@ where
 mod tests {
     use crate::decoders::DictionaryDecoder;
     use crate::decoders::token_decoder::TokenDecoder;
+    use crate::encoders::merge_heap_encoder::MergeHeapVocabEncoder;
     use crate::encoders::token_encoder::TokenEncoder;
-    use crate::encoders::unified_encoder::UnifiedVocabEncoder;
     use crate::regex::default_regex_supplier;
     use crate::training::bpe_trainer::{BinaryPairVocabTrainerOptions, MergeJob};
     use crate::types::{check_is_send, check_is_sync};
@@ -440,15 +440,15 @@ mod tests {
 
         let byte_table: Arc<ByteTokenTable<T>> = Arc::new(Default::default());
 
-        let vocab: UnifiedTokenVocab<T> = trainer.train(byte_table.clone()).unwrap();
+        let vocab: Arc<UnifiedTokenVocab<T>> = trainer.train(byte_table.clone()).unwrap().into();
 
-        let encoder = UnifiedVocabEncoder::<T>::init(vocab.clone().into(), default_regex_supplier);
+        let encoder = MergeHeapVocabEncoder::<T>::init(vocab.clone(), default_regex_supplier);
         check_is_send(&encoder);
         check_is_sync(&encoder);
 
         assert_eq!(encoder.max_token(), 292);
 
-        let decoder = DictionaryDecoder::new(vocab.unified_dictionary());
+        let decoder = DictionaryDecoder::from_unified_vocab(vocab);
         check_is_send(&decoder);
         check_is_sync(&decoder);
 

--- a/crates/wordchuck/src/vocab/pair_vocab.rs
+++ b/crates/wordchuck/src/vocab/pair_vocab.rs
@@ -98,7 +98,7 @@ impl<T: TokenType> PairTokenMapVocab<T> {
     ///
     /// This includes the pairs from the `ByteTable`.
     pub fn span_pairs(&self) -> impl Iterator<Item = (Vec<u8>, T)> {
-        let decoder = PairExpansionDecoder::from_pair_map(self.byte_table().clone(), self.pairs());
+        let decoder = PairExpansionDecoder::from_pair_vocab(self);
 
         self.byte_table.span_pairs().chain(
             self.pairs


### PR DESCRIPTION
Rename `UnifiedVocabEncoder` to `MergeHeapVocabEncoder` for improved accuracy and consistency across encoders. Update associated references, tests, and examples to align with the new naming convention.