### PR TITLE
string conversion fallback.

### DIFF
--- a/crates/wordchuck/src/decoders/token_decoder.rs
+++ b/crates/wordchuck/src/decoders/token_decoder.rs
@@ -2,6 +2,7 @@
 
 use crate::decoders::TokenDecodeContext;
 use crate::types::TokenType;
+use crate::vocab::utility::strings::string_from_lossy_utf8;
 
 /// Trait for token decoders.
 pub trait TokenDecoder<T: TokenType>: Send + Sync {
@@ -53,7 +54,7 @@ pub trait TokenDecoder<T: TokenType>: Send + Sync {
         &self,
         tokens: S,
     ) -> anyhow::Result<String> {
-        Ok(String::from_utf8_lossy(&self.try_decode_to_bytes(tokens)?).to_string())
+        Ok(string_from_lossy_utf8(self.try_decode_to_bytes(tokens)?))
     }
 
     /// Decodes a batch of tokens into a vector of strings, returning an error if the decoding fails.
@@ -63,11 +64,11 @@ pub trait TokenDecoder<T: TokenType>: Send + Sync {
         &self,
         batch: &[Vec<T>],
     ) -> anyhow::Result<Vec<String>> {
-        self.try_decode_batch_to_bytes(batch).map(|b| {
-            b.iter()
-                .map(|b| String::from_utf8_lossy(b).to_string())
-                .collect()
-        })
+        Ok(self
+            .try_decode_batch_to_bytes(batch)?
+            .into_iter()
+            .map(string_from_lossy_utf8)
+            .collect())
     }
 }
 

--- a/crates/wordchuck/src/rayon/rayon_decoder.rs
+++ b/crates/wordchuck/src/rayon/rayon_decoder.rs
@@ -2,6 +2,7 @@
 
 use crate::decoders::{TokenDecodeContext, TokenDecoder};
 use crate::types::TokenType;
+use crate::vocab::utility::strings::string_from_lossy_utf8;
 
 /// Batch-Level Parallel Decoder Wrapper.
 ///
@@ -61,8 +62,8 @@ where
         batch
             .into_par_iter()
             .map(|tokens| {
-                let bs = self.try_decode_to_bytes(tokens)?;
-                Ok(String::from_utf8_lossy(&bs).to_string())
+                let buf = self.try_decode_to_bytes(tokens)?;
+                Ok(string_from_lossy_utf8(buf))
             })
             .collect()
     }

--- a/crates/wordchuck/src/vocab/utility/mod.rs
+++ b/crates/wordchuck/src/vocab/utility/mod.rs
@@ -3,5 +3,6 @@
 pub mod pattern_tools;
 pub mod resource_tools;
 pub mod specials_tools;
+pub mod strings;
 pub mod testing;
 pub mod validators;

--- a/crates/wordchuck/src/vocab/utility/strings.rs
+++ b/crates/wordchuck/src/vocab/utility/strings.rs
@@ -1,0 +1,17 @@
+//! # String Utilities
+
+use alloc::borrow::Cow;
+
+/// "stable" stub for for [`String::from_utf8_lossy`].
+pub fn string_from_lossy_utf8(v: Vec<u8>) -> String {
+    if let Cow::Owned(string) = String::from_utf8_lossy(&v) {
+        string
+    } else {
+        // SAFETY: `String::from_utf8_lossy`'s contract ensures that if
+        // it returns a `Cow::Borrowed`, it is a valid UTF-8 string.
+        // Otherwise, it returns a new allocation of an owned `String`, with
+        // replacement characters for invalid sequences, which is returned
+        // above.
+        unsafe { String::from_utf8_unchecked(v) }
+    }
+}


### PR DESCRIPTION
Replace `String::from_utf8_lossy` with `string_from_lossy_utf8` for unified decoding logic (#87)

Introduce `string_from_lossy_utf8` utility to standardize decoding behavior. Update `rayon_decoder` and `token_decoder` to use the new utility. Modularize string utilities under `vocab::utility::strings`.