### PR TITLE
Refactor `MergeHeapVocabEncoder` initialization and remove `default_r…

### DIFF
--- a/.idea/runConfigurations/Doc.xml
+++ b/.idea/runConfigurations/Doc.xml
@@ -1,7 +1,7 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Doc" type="CargoCommandRunConfiguration" factoryName="Cargo Command">
     <option name="buildProfileId" value="dev" />
-    <option name="command" value="doc --no-deps --quiet" />
+    <option name="command" value="doc --no-deps --quiet --all-features" />
     <option name="workingDirectory" value="file://$PROJECT_DIR$" />
     <envs />
     <option name="emulateTerminal" value="true" />

--- a/crates/wordchuck/Cargo.toml
+++ b/crates/wordchuck/Cargo.toml
@@ -8,6 +8,9 @@ license.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 
+[package.metadata.docs.rs]
+all-features = true
+
 
 [lints]
 workspace = true

--- a/crates/wordchuck/examples/token-cli/src/main.rs
+++ b/crates/wordchuck/examples/token-cli/src/main.rs
@@ -85,7 +85,7 @@ fn run_load(
         UnifiedTokenVocab::from_span_vocab(segmentation, span_map.into()).into();
 
     let encoder: MergeHeapVocabEncoder<T> =
-        MergeHeapVocabEncoder::<T>::init(vocab.clone(), regex_pool_supplier);
+        MergeHeapVocabEncoder::<T>::init_with_factory(vocab.clone(), regex_pool_supplier);
     let encoder = ParallelRayonEncoder::new(encoder);
 
     let decoder = DictionaryDecoder::from_unified_vocab(vocab.clone());

--- a/crates/wordchuck/examples/tokenizer_trainer/src/main.rs
+++ b/crates/wordchuck/examples/tokenizer_trainer/src/main.rs
@@ -9,7 +9,6 @@ use std::time::Duration;
 use wordchuck::decoders::{DictionaryDecoder, TokenDecoder};
 use wordchuck::encoders::{MergeHeapVocabEncoder, TokenEncoder};
 use wordchuck::rayon::{ParallelRayonDecoder, ParallelRayonEncoder};
-use wordchuck::regex::default_regex_supplier;
 use wordchuck::training::BinaryPairVocabTrainerOptions;
 use wordchuck::vocab::byte_vocab::ByteVocab;
 use wordchuck::vocab::io::tiktoken_io::save_span_map_to_tiktoken_path;
@@ -134,8 +133,7 @@ fn main() -> anyhow::Result<()> {
     }
 
     if args.time_encode_decode {
-        let encoder: MergeHeapVocabEncoder<T> =
-            MergeHeapVocabEncoder::<T>::init(vocab.clone(), default_regex_supplier);
+        let encoder: MergeHeapVocabEncoder<T> = MergeHeapVocabEncoder::<T>::init(vocab.clone());
         let encoder = ParallelRayonEncoder::new(encoder);
 
         let decoder = DictionaryDecoder::from_unified_vocab(vocab);

--- a/crates/wordchuck/src/decoders/dictionary_decoder.rs
+++ b/crates/wordchuck/src/decoders/dictionary_decoder.rs
@@ -30,7 +30,7 @@ impl<T: TokenType> DictionaryDecoder<T> {
 }
 
 impl<T: TokenType> TokenDecoder<T> for DictionaryDecoder<T> {
-    #[cfg_attr(feature = "tracing", tracing::instrument(skip(self, buf, tokens)))]
+    #[cfg_attr(feature = "tracing", tracing::instrument(skip(self, ctx)))]
     fn incremental_decode(
         &self,
         ctx: &mut TokenDecodeContext<T>,
@@ -52,7 +52,6 @@ mod tests {
     use super::*;
     use crate::encoders::merge_heap_encoder::MergeHeapVocabEncoder;
     use crate::encoders::token_encoder::TokenEncoder;
-    use crate::regex::default_regex_supplier;
     use crate::segmentation::SegmentationConfig;
     use crate::types::{check_is_send, check_is_sync};
     use crate::vocab::byte_vocab::ByteVocab;
@@ -76,7 +75,7 @@ mod tests {
         let vocab: Arc<UnifiedTokenVocab<T>> =
             build_test_vocab(byte_vocab.clone(), segmentation).into();
 
-        let encoder = MergeHeapVocabEncoder::<T>::init(vocab.clone(), default_regex_supplier);
+        let encoder = MergeHeapVocabEncoder::<T>::init(vocab.clone());
 
         let decoder = DictionaryDecoder::from_unified_vocab(vocab.clone());
         check_is_send(&decoder);

--- a/crates/wordchuck/src/decoders/mod.rs
+++ b/crates/wordchuck/src/decoders/mod.rs
@@ -1,4 +1,26 @@
 //! # Token Decoders
+//!
+//! ## Example
+//!
+//! ```rust,no_run
+//! use wordchuck::vocab::UnifiedTokenVocab;
+//! use wordchuck::decoders::DictionaryDecoder;
+//! use wordchuck::decoders::TokenDecoder;
+//! use wordchuck::types::TokenType;
+//! use std::sync::Arc;
+//!
+//! fn example<T: TokenType>(
+//!     vocab: Arc<UnifiedTokenVocab<T>>,
+//!     batch: &[Vec<T>],
+//! ) -> Vec<String> {
+//!     let decoder: DictionaryDecoder<T> = DictionaryDecoder::from_unified_vocab(vocab);
+//!
+//!     #[cfg(feature = "rayon")]
+//!     let decoder = wordchuck::rayon::ParallelRayonDecoder::new(decoder);
+//!
+//!     decoder.try_decode_batch_to_strings(batch).unwrap()
+//! }
+//! ```
 
 pub mod decode_context;
 pub mod dictionary_decoder;

--- a/crates/wordchuck/src/decoders/utility/byte_decoder.rs
+++ b/crates/wordchuck/src/decoders/utility/byte_decoder.rs
@@ -31,7 +31,7 @@ impl<T: TokenType> ByteDecoder<T> {
 }
 
 impl<T: TokenType> TokenDecoder<T> for ByteDecoder<T> {
-    #[cfg_attr(feature = "tracing", tracing::instrument(skip(self, buf, tokens)))]
+    #[cfg_attr(feature = "tracing", tracing::instrument(skip(self, ctx)))]
     fn incremental_decode(
         &self,
         ctx: &mut TokenDecodeContext<T>,

--- a/crates/wordchuck/src/decoders/utility/pair_decoder.rs
+++ b/crates/wordchuck/src/decoders/utility/pair_decoder.rs
@@ -48,7 +48,7 @@ impl<T: TokenType> PairExpansionDecoder<T> {
 }
 
 impl<T: TokenType> TokenDecoder<T> for PairExpansionDecoder<T> {
-    #[cfg_attr(feature = "tracing", tracing::instrument(skip(self, buf, tokens)))]
+    #[cfg_attr(feature = "tracing", tracing::instrument(skip(self, ctx)))]
     fn incremental_decode(
         &self,
         ctx: &mut TokenDecodeContext<T>,
@@ -73,7 +73,6 @@ mod tests {
     use super::*;
     use crate::encoders::merge_heap_encoder::MergeHeapVocabEncoder;
     use crate::encoders::token_encoder::TokenEncoder;
-    use crate::regex::default_regex_supplier;
     use crate::segmentation::SegmentationConfig;
     use crate::types::{check_is_send, check_is_sync};
     use crate::vocab::UnifiedTokenVocab;
@@ -99,7 +98,7 @@ mod tests {
         )
         .into();
 
-        let encoder = MergeHeapVocabEncoder::<T>::init(vocab.clone(), default_regex_supplier);
+        let encoder = MergeHeapVocabEncoder::<T>::init(vocab.clone());
 
         let decoder = PairExpansionDecoder::from_pair_vocab(&vocab.pair_vocab);
         check_is_send(&decoder);

--- a/crates/wordchuck/src/encoders/merge_heap_encoder.rs
+++ b/crates/wordchuck/src/encoders/merge_heap_encoder.rs
@@ -1,7 +1,7 @@
 //! # Encoder for [`UnifiedTokenVocab`].
 
 use crate::encoders::token_encoder::TokenEncoder;
-use crate::regex::{RegexSupplierHandle, RegexWrapperHandle};
+use crate::regex::{RegexSupplierHandle, RegexWrapperHandle, default_regex_supplier};
 use crate::segmentation::text_segmentor::TextSegmentor;
 use crate::types::TokenType;
 use crate::vocab::special_vocab::SpecialVocab;
@@ -20,7 +20,12 @@ pub struct MergeHeapVocabEncoder<T: TokenType> {
 
 impl<T: TokenType> MergeHeapVocabEncoder<T> {
     /// Construct an encoder from data.
-    pub fn init<F>(
+    pub fn init(data: Arc<UnifiedTokenVocab<T>>) -> Self {
+        Self::init_with_factory(data, default_regex_supplier)
+    }
+
+    /// Construct an encoder from data.
+    pub fn init_with_factory<F>(
         data: Arc<UnifiedTokenVocab<T>>,
         re_factory: F,
     ) -> Self
@@ -154,17 +159,13 @@ impl<T: TokenType> TokenEncoder<T> for MergeHeapVocabEncoder<T> {
 
 #[cfg(test)]
 mod tests {
-    use crate::decoders::DictionaryDecoder;
-    use crate::decoders::token_decoder::TokenDecoder;
-    use crate::encoders::merge_heap_encoder::MergeHeapVocabEncoder;
-    use crate::encoders::token_encoder::TokenEncoder;
-    use crate::regex::default_regex_supplier;
+    use crate::decoders::{DictionaryDecoder, TokenDecoder};
+    use crate::encoders::{MergeHeapVocabEncoder, TokenEncoder};
     use crate::segmentation::SegmentationConfig;
     use crate::types::{check_is_send, check_is_sync};
-    use crate::vocab::UnifiedTokenVocab;
-    use crate::vocab::byte_vocab::ByteVocab;
     use crate::vocab::public::openai::patterns::OA_GPT3_CL100K_WORD_PATTERN;
     use crate::vocab::utility::testing::build_test_vocab;
+    use crate::vocab::{ByteVocab, UnifiedTokenVocab};
     use alloc::sync::Arc;
 
     #[test]
@@ -189,7 +190,7 @@ mod tests {
 
         let special_sample = "hello <|HI|> world";
 
-        let encoder = MergeHeapVocabEncoder::<T>::init(vocab.clone(), default_regex_supplier);
+        let encoder = MergeHeapVocabEncoder::<T>::init(vocab.clone());
         check_is_send(&encoder);
         check_is_sync(&encoder);
 

--- a/crates/wordchuck/src/encoders/mod.rs
+++ b/crates/wordchuck/src/encoders/mod.rs
@@ -1,4 +1,25 @@
 //! # Token Encoders
+//!
+//! ## Examples
+//!
+//! ```rust,no_run
+//! use wordchuck::vocab::UnifiedTokenVocab;
+//! use wordchuck::encoders::MergeHeapVocabEncoder;
+//! use wordchuck::types::TokenType;
+//! use std::sync::Arc;
+//!
+//! fn example<T: TokenType>(
+//!     vocab: Arc<UnifiedTokenVocab<T>>,
+//!     batch: &[String],
+//! ) -> Vec<Vec<T>> {
+//!     let encoder: MergeHeapVocabEncoder<T> = MergeHeapVocabEncoder::init(vocab);
+//!
+//!     #[cfg(feature = "rayon")]
+//!     let encoder = wordchuck::rayon::RayonEncoder::new(encoder);
+//!
+//!     encoder.encode_batch(batch);
+//! }
+//! ```
 
 pub mod merge_heap_encoder;
 pub mod token_encoder;

--- a/crates/wordchuck/src/encoders/mod.rs
+++ b/crates/wordchuck/src/encoders/mod.rs
@@ -1,10 +1,11 @@
 //! # Token Encoders
 //!
-//! ## Examples
+//! ## Example
 //!
 //! ```rust,no_run
 //! use wordchuck::vocab::UnifiedTokenVocab;
 //! use wordchuck::encoders::MergeHeapVocabEncoder;
+//! use wordchuck::encoders::TokenEncoder;
 //! use wordchuck::types::TokenType;
 //! use std::sync::Arc;
 //!
@@ -15,9 +16,9 @@
 //!     let encoder: MergeHeapVocabEncoder<T> = MergeHeapVocabEncoder::init(vocab);
 //!
 //!     #[cfg(feature = "rayon")]
-//!     let encoder = wordchuck::rayon::RayonEncoder::new(encoder);
+//!     let encoder = wordchuck::rayon::ParallelRayonEncoder::new(encoder);
 //!
-//!     encoder.encode_batch(batch);
+//!     encoder.try_encode_batch(batch).unwrap()
 //! }
 //! ```
 

--- a/crates/wordchuck/src/rayon/rayon_decoder.rs
+++ b/crates/wordchuck/src/rayon/rayon_decoder.rs
@@ -75,7 +75,6 @@ mod tests {
     use crate::decoders::DictionaryDecoder;
     use crate::encoders::MergeHeapVocabEncoder;
     use crate::encoders::token_encoder::TokenEncoder;
-    use crate::regex::default_regex_supplier;
     use crate::segmentation::SegmentationConfig;
     use crate::types::{check_is_send, check_is_sync};
     use crate::vocab::UnifiedTokenVocab;
@@ -102,7 +101,7 @@ mod tests {
         )
         .into();
 
-        let encoder = MergeHeapVocabEncoder::<T>::init(vocab.clone(), default_regex_supplier);
+        let encoder = MergeHeapVocabEncoder::<T>::init(vocab.clone());
 
         let decoder = ParallelRayonDecoder::new(DictionaryDecoder::from_unified_vocab(vocab));
         check_is_send(&decoder);

--- a/crates/wordchuck/src/rayon/rayon_encoder.rs
+++ b/crates/wordchuck/src/rayon/rayon_encoder.rs
@@ -66,7 +66,6 @@ mod tests {
     use crate::decoders::{DictionaryDecoder, TokenDecoder};
     use crate::encoders::{MergeHeapVocabEncoder, TokenEncoder};
     use crate::rayon::rayon_encoder::ParallelRayonEncoder;
-    use crate::regex::default_regex_supplier;
     use crate::segmentation::SegmentationConfig;
     use crate::types::{check_is_send, check_is_sync};
     use crate::vocab::UnifiedTokenVocab;
@@ -93,7 +92,7 @@ mod tests {
 
         let special_sample = "hello <|HI|> world";
 
-        let encoder = MergeHeapVocabEncoder::<T>::init(vocab.clone(), default_regex_supplier);
+        let encoder = MergeHeapVocabEncoder::<T>::init(vocab.clone());
         check_is_send(&encoder);
         check_is_sync(&encoder);
 

--- a/crates/wordchuck/src/training/bpe_trainer.rs
+++ b/crates/wordchuck/src/training/bpe_trainer.rs
@@ -388,16 +388,13 @@ where
 
 #[cfg(test)]
 mod tests {
-    use crate::decoders::DictionaryDecoder;
-    use crate::decoders::token_decoder::TokenDecoder;
-    use crate::encoders::merge_heap_encoder::MergeHeapVocabEncoder;
-    use crate::encoders::token_encoder::TokenEncoder;
-    use crate::regex::default_regex_supplier;
-    use crate::training::bpe_trainer::{BinaryPairVocabTrainerOptions, MergeJob};
+    use crate::decoders::{DictionaryDecoder, TokenDecoder};
+    use crate::encoders::{MergeHeapVocabEncoder, TokenEncoder};
+    use crate::training::BinaryPairVocabTrainerOptions;
+    use crate::training::bpe_trainer::MergeJob;
     use crate::types::{check_is_send, check_is_sync};
-    use crate::vocab::byte_vocab::ByteVocab;
     use crate::vocab::public::openai::patterns::OA_GPT3_CL100K_WORD_PATTERN;
-    use crate::vocab::unified_vocab::UnifiedTokenVocab;
+    use crate::vocab::{ByteVocab, UnifiedTokenVocab};
     use alloc::sync::Arc;
     use compact_str::CompactString;
     use core::cmp::Ordering;
@@ -442,7 +439,7 @@ mod tests {
 
         let vocab: Arc<UnifiedTokenVocab<T>> = trainer.train(byte_vocab.clone()).unwrap().into();
 
-        let encoder = MergeHeapVocabEncoder::<T>::init(vocab.clone(), default_regex_supplier);
+        let encoder = MergeHeapVocabEncoder::<T>::init(vocab.clone());
         check_is_send(&encoder);
         check_is_sync(&encoder);
 

--- a/crates/wordchuck/src/training/mod.rs
+++ b/crates/wordchuck/src/training/mod.rs
@@ -15,7 +15,6 @@
 //! use wordchuck::encoders::MergeHeapVocabEncoder;
 //! use wordchuck::decoders::DictionaryDecoder;
 //! use wordchuck::rayon::{ParallelRayonEncoder, ParallelRayonDecoder};
-//! use wordchuck::regex::default_regex_supplier;
 //! use std::sync::Arc;
 //!
 //! fn example<I, S>(
@@ -61,10 +60,7 @@
 //!         println!("- tiktoken vocab: {path:?}");
 //!     }
 //!
-//!     let encoder: MergeHeapVocabEncoder<T> = MergeHeapVocabEncoder::<T>::init(
-//!         vocab.clone(),
-//!         default_regex_supplier
-//!     );
+//!     let encoder: MergeHeapVocabEncoder<T> = MergeHeapVocabEncoder::init(vocab.clone());
 //!     let encoder = ParallelRayonEncoder::new(encoder);
 //!
 //!     let decoder = DictionaryDecoder::from_unified_vocab(vocab.clone());


### PR DESCRIPTION
…egex_supplier` dependency.

Simplify encoder lifecycle by introducing `init_with_factory` API for optional regex supplier usage. Clean up unused imports and update tests, examples, and documentation to reflect changes. Enable `docs.rs` to build with all features.