### PR TITLE
Refactor feature dependencies and "std" feature management across `wo…

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ clap = "^4.5"
 anyhow = "^1.0"
 shellexpand = "^3.1"
 
-num-traits = "^0.2.19"
+num-traits = {  version = "^0.2.19", default-features = false }
 compact_str = "^0.9"
 ahash = "^0.8"
 dary_heap = "^0.3"
@@ -46,7 +46,7 @@ parking_lot = "^0.12.5"
 
 rayon = "^1.11"
 
-base64 = "^0.22.1"
+base64 = {  version = "^0.22.1" }
 serde = "^1.0"
 
 downloader = "^0.2"

--- a/crates/wordchuck/Cargo.toml
+++ b/crates/wordchuck/Cargo.toml
@@ -22,7 +22,7 @@ default = ["rayon"]
 # This is only partial support for no_std.
 # It *is* tested by CI, but it isn't propagated to the dependents of this crate;
 # and some of those will require feature degradation.
-std = []
+std = ["dep:base64", "num-traits/std", "dep:parking_lot"]
 
 training = ["std", "compact_str", "dary_heap"]
 
@@ -32,20 +32,21 @@ tracing = ["dep:tracing"]
 # We can switch HashMap/HashSet implementations for the whole crate.
 # This is done in the "src/types.rs" file.
 #
-# "ahash" is here as an example of how to do this;
-# but in my testing it provides only a small improvement
-# to decode, and actually degrades encode.
+# - mac hardware: fasster to enable ahash
+# - 2020 desktop linux: faster decode, no encode benefit.
 ahash = ["dep:ahash", "std"]
 
 
 [dependencies]
 anyhow = { workspace = true }
-base64 = { workspace = true }
 fancy-regex = { workspace = true }
 log = { workspace = true }
 num-traits = { workspace = true }
-parking_lot = { workspace = true }
 regex = { workspace = true }
+
+# "std" feature deps:
+base64 = { workspace = true, optional = true }
+parking_lot = { workspace = true, optional = true }
 
 # "ahash" feature deps:
 ahash = { workspace = true, optional = true }

--- a/crates/wordchuck/src/vocab/mod.rs
+++ b/crates/wordchuck/src/vocab/mod.rs
@@ -20,8 +20,10 @@
 //! Metadata and load support for a number of public pre-trained tokenizers
 //! exists in [`public`].
 
-pub mod byte_vocab;
+#[cfg(feature = "std")]
 pub mod io;
+
+pub mod byte_vocab;
 pub mod pair_vocab;
 pub mod public;
 pub mod span_vocab;


### PR DESCRIPTION
…rdchuck` crate

- Update `Cargo.toml` to specify optional "std" dependencies (`base64`, `parking_lot`, `num-traits`) and disable default features for `num-traits`.
- Adjust `vocab/mod.rs` module visibility with `std` feature gating.
- Improve cross-platform compatibility and modularization of dependencies.