### PR TITLE
Update feature configurations and dependencies across crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,9 +29,9 @@ burn = "^0.20.0"
 bimm-contracts = "^0.19.2"
 
 tracing = "^0.1"
-log = "^0.4"
+log = { version = "^0.4", default-features = false }
 clap = "^4.5"
-anyhow = "^1.0"
+anyhow = { version = "^1.0" , default-features = false }
 shellexpand = "^3.1"
 
 num-traits = {  version = "^0.2.19", default-features = false }

--- a/crates/nanochat/Cargo.toml
+++ b/crates/nanochat/Cargo.toml
@@ -11,7 +11,7 @@ publish = false
 burn = { workspace = true }
 bimm-contracts = { workspace = true, features = ["burn"] }
 
-anyhow = { workspace = true }
+anyhow = { workspace = true, features = ["std"]}
 
 [dev-dependencies]
 burn = { workspace = true, features = ["wgpu"] }

--- a/crates/wordchuck/Cargo.toml
+++ b/crates/wordchuck/Cargo.toml
@@ -17,16 +17,30 @@ workspace = true
 
 
 [features]
-default = ["rayon"]
+default = ["std", "ahash", "rayon"]
 
 # This is only partial support for no_std.
 # It *is* tested by CI, but it isn't propagated to the dependents of this crate;
 # and some of those will require feature degradation.
-std = ["dep:base64", "num-traits/std", "dep:parking_lot"]
+std = [
+    "anyhow/std",
+    "dep:base64",
+    "dep:parking_lot",
+    "num-traits/std",
+    "log/std",
+]
 
-training = ["std", "compact_str", "dary_heap"]
+training = [
+    "compact_str",
+    "dary_heap",
+    "std",
+]
 
-rayon = ["dep:rayon", "std"]
+rayon = [
+    "dep:rayon",
+    "std"
+]
+
 tracing = ["dep:tracing"]
 
 # We can switch HashMap/HashSet implementations for the whole crate.
@@ -34,15 +48,20 @@ tracing = ["dep:tracing"]
 #
 # - mac hardware: fasster to enable ahash
 # - 2020 desktop linux: faster decode, no encode benefit.
-ahash = ["dep:ahash", "std"]
+ahash = [
+    "dep:ahash",
+    "std",
+]
 
 
 [dependencies]
-anyhow = { workspace = true }
 fancy-regex = { workspace = true }
+regex = { workspace = true }
+
+# no-default deps
+anyhow = { workspace = true }
 log = { workspace = true }
 num-traits = { workspace = true }
-regex = { workspace = true }
 
 # "std" feature deps:
 base64 = { workspace = true, optional = true }


### PR DESCRIPTION

- Expanded the `std` feature in the `wordchuck` crate to include additional dependencies: `anyhow/std` and `log/std`.
- Refactored feature groupings (`default`, `training`, `rayon`, `ahash`) for improved clarity.
- Updated dependency management by disabling default features for `anyhow`, `log`, and `num-traits` to ensure consistent behavior.
- Adjusted the `nanochat` crate to enable the `std` feature for its `anyhow` dependency.
